### PR TITLE
アップデート ver 1.05

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# テンプレート（コピーして .env.development / .env.production を作成）
+# Vite は VITE_ で始まる変数のみクライアントに埋め込みます。
+#
+# npm run dev    → .env.development
+# npm run build  → .env.production
+
+VITE_FIREBASE_API_KEY=
+VITE_FIREBASE_AUTH_DOMAIN=
+VITE_FIREBASE_PROJECT_ID=
+VITE_FIREBASE_STORAGE_BUCKET=
+VITE_FIREBASE_MESSAGING_SENDER_ID=
+VITE_FIREBASE_APP_ID=

--- a/.firebaserc
+++ b/.firebaserc
@@ -1,5 +1,6 @@
 {
   "projects": {
-    "default": "expense-tracker-app-f2e67"
+    "default": "expense-tracker-app-f2e67",
+    "dev": "expense-tracker-dev-cb4b1"
   }
 }

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,0 +1,17 @@
+---
+name: Custom issue template
+about: Describe this issue template's purpose here.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## 概要
+
+## 目的
+
+## タスク
+- [ ]
+
+## その他

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,10 @@ ehthumbs.db
 Thumbs.db
 
 # 環境変数ファイル (Environment variables)
+# .env.example のみコミット可（実値は含めない）
 .env
+.env.development
+.env.production
 .env.local
 .env.development.local
 .env.test.local

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,51 +1,21 @@
 {
-  // Example (Standard Edition):
-  //
-  // "indexes": [
-  //   {
-  //     "collectionGroup": "widgets",
-  //     "queryScope": "COLLECTION",
-  //     "fields": [
-  //       { "fieldPath": "foo", "arrayConfig": "CONTAINS" },
-  //       { "fieldPath": "bar", "mode": "DESCENDING" }
-  //     ]
-  //   },
-  //
-  //  "fieldOverrides": [
-  //    {
-  //      "collectionGroup": "widgets",
-  //      "fieldPath": "baz",
-  //      "indexes": [
-  //        { "order": "ASCENDING", "queryScope": "COLLECTION" }
-  //      ]
-  //    },
-  //   ]
-  // ]
-  //
-  // Example (Enterprise Edition):
-  //
-  // "indexes": [
-  //   {
-  //     "collectionGroup": "reviews",
-  //     "queryScope": "COLLECTION_GROUP",
-  //     "apiScope": "MONGODB_COMPATIBLE_API",
-  //     "density": "DENSE",
-  //     "multikey": false,
-  //     "fields": [
-  //       { "fieldPath": "baz", "mode": "ASCENDING" }
-  //     ]
-  //   },
-  //   {
-  //     "collectionGroup": "items",
-  //     "queryScope": "COLLECTION_GROUP",
-  //     "apiScope": "MONGODB_COMPATIBLE_API",
-  //     "density": "SPARSE_ANY",
-  //     "multikey": true,
-  //     "fields": [
-  //       { "fieldPath": "baz", "mode": "ASCENDING" }
-  //     ]
-  //   },
-  // ]
-  "indexes": [],
+  "indexes": [
+    {
+      "collectionGroup": "expenses",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "date", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "expenses",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "date", "order": "ASCENDING" }
+      ]
+    }
+  ],
   "fieldOverrides": []
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -23,6 +23,11 @@ service cloud.firestore {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }
 
+    // 月次支出合計（ダッシュボード用・読取削減）
+    match /users/{userId}/monthlyTotals/{periodId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
     // その他のコレクション: 認証済みユーザーのみアクセス可能（必要に応じて調整）
     match /{document=**} {
       allow read, write: if request.auth != null;

--- a/src/components/ExpenseForm.test.tsx
+++ b/src/components/ExpenseForm.test.tsx
@@ -3,12 +3,12 @@ import { render, screen, waitFor } from '../test/testUtils'
 import { ExpenseForm } from './ExpenseForm'
 import { useCategories } from '../hooks/useCategories'
 import { useTags } from '../hooks/useTags'
-import { useExpenses } from '../hooks/useExpenses'
+import { useExpenseMutations } from '../hooks/useExpenseMutations'
 
 // モック
 vi.mock('../hooks/useCategories')
 vi.mock('../hooks/useTags')
-vi.mock('../hooks/useExpenses')
+vi.mock('../hooks/useExpenseMutations')
 vi.mock('../services/categoryService', () => ({
   categoryService: {
     createCategory: vi.fn(),
@@ -45,11 +45,7 @@ describe('ExpenseForm', () => {
       error: null,
       refreshTags: vi.fn(),
     })
-    vi.mocked(useExpenses).mockReturnValue({
-      expenses: [],
-      loading: false,
-      error: null,
-      refreshExpenses: vi.fn(),
+    vi.mocked(useExpenseMutations).mockReturnValue({
       createExpense: mockCreateExpense,
       updateExpense: vi.fn(),
       deleteExpense: vi.fn(),
@@ -155,6 +151,43 @@ describe('ExpenseForm', () => {
     await waitFor(
       () => {
         expect(mockCreateExpense).toHaveBeenCalled()
+        expect(mockOnSuccess).toHaveBeenCalled()
+      },
+      { timeout: 3000 }
+    )
+  })
+
+  it('should call createExpense without payment method when left unselected', async () => {
+    const userEvent = (await import('@testing-library/user-event')).default.setup()
+
+    mockCreateExpense.mockResolvedValue(undefined)
+    global.alert = vi.fn()
+
+    render(<ExpenseForm userId="test-user" onSuccess={mockOnSuccess} />)
+
+    const dateInput = screen.getByLabelText(/日付/) as HTMLInputElement
+    await userEvent.clear(dateInput)
+    await userEvent.type(dateInput, '2024-01-01')
+
+    const amountInput = screen.getByLabelText(/金額/) as HTMLInputElement
+    await userEvent.clear(amountInput)
+    await userEvent.type(amountInput, '500')
+
+    const categorySelect = screen.getByLabelText(/カテゴリー/) as HTMLSelectElement
+    await userEvent.selectOptions(categorySelect, '食費')
+
+    const submitButton = screen.getByRole('button', { name: '登録' })
+    await userEvent.click(submitButton)
+
+    await waitFor(
+      () => {
+        expect(mockCreateExpense).toHaveBeenCalledWith(
+          expect.objectContaining({
+            amount: 500,
+            bigCategory: '食費',
+            paymentMethod: undefined,
+          })
+        )
         expect(mockOnSuccess).toHaveBeenCalled()
       },
       { timeout: 3000 }

--- a/src/components/ExpenseForm.tsx
+++ b/src/components/ExpenseForm.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useCategories } from '../hooks/useCategories'
 import { useTags } from '../hooks/useTags'
-import { useExpenses } from '../hooks/useExpenses'
+import { useExpenseMutations } from '../hooks/useExpenseMutations'
 import { categoryService } from '../services/categoryService'
 import { DEFAULT_CATEGORIES } from '../constants/defaultCategories'
 import { PAYMENT_METHODS } from '../constants/paymentMethods'
@@ -18,7 +18,7 @@ export const ExpenseForm = ({ userId, onSuccess }: ExpenseFormProps) => {
   const [formData, setFormData] = useState(getInitialExpenseFormData())
   const [submitting, setSubmitting] = useState<boolean>(false)
   const { categories, loading: loadingCategories, refreshCategories } = useCategories()
-  const { createExpense } = useExpenses(userId)
+  const { createExpense } = useExpenseMutations(userId)
 
   // 選択されたカテゴリーIDを取得
   const selectedCategoryId = categories.find(
@@ -39,7 +39,7 @@ export const ExpenseForm = ({ userId, onSuccess }: ExpenseFormProps) => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
 
-    if (!formData.date || !formData.amount || !formData.bigCategory || !formData.paymentMethod) {
+    if (!formData.date || !formData.amount || !formData.bigCategory) {
       alert('必須項目を入力してください')
       return
     }
@@ -57,7 +57,7 @@ export const ExpenseForm = ({ userId, onSuccess }: ExpenseFormProps) => {
         amount: amount,
         bigCategory: formData.bigCategory,
         tags: formData.tags,
-        paymentMethod: formData.paymentMethod,
+        paymentMethod: formData.paymentMethod || undefined,
         description: formData.description,
       })
 
@@ -158,14 +158,13 @@ export const ExpenseForm = ({ userId, onSuccess }: ExpenseFormProps) => {
         </div>
 
         <div className="form-group">
-          <label htmlFor="paymentMethod">支払い方法 <span className="required">*</span></label>
+          <label htmlFor="paymentMethod">支払い方法</label>
           <select
             id="paymentMethod"
             value={formData.paymentMethod}
             onChange={(e) => setFormData({ ...formData, paymentMethod: e.target.value })}
-            required
           >
-            <option value="">選択してください</option>
+            <option value="">未選択</option>
             {PAYMENT_METHODS.map((method) => (
               <option key={method} value={method}>
                 {method}

--- a/src/components/ExpenseModal.test.tsx
+++ b/src/components/ExpenseModal.test.tsx
@@ -3,14 +3,14 @@ import { render, screen, waitFor } from '../test/testUtils'
 import { ExpenseModal } from './ExpenseModal'
 import { useCategories } from '../hooks/useCategories'
 import { useTags } from '../hooks/useTags'
-import { useExpenses } from '../hooks/useExpenses'
+import { useExpenseMutations } from '../hooks/useExpenseMutations'
 import { Timestamp } from 'firebase/firestore'
 import type { Expense } from '../types'
 
 // モック
 vi.mock('../hooks/useCategories')
 vi.mock('../hooks/useTags')
-vi.mock('../hooks/useExpenses')
+vi.mock('../hooks/useExpenseMutations')
 
 const mockCategories = [
   { id: 'cat1', name: '食費' },
@@ -60,11 +60,7 @@ describe('ExpenseModal', () => {
       error: null,
       refreshTags: vi.fn(),
     })
-    vi.mocked(useExpenses).mockReturnValue({
-      expenses: [],
-      loading: false,
-      error: null,
-      refreshExpenses: vi.fn(),
+    vi.mocked(useExpenseMutations).mockReturnValue({
       createExpense: vi.fn(),
       updateExpense: mockUpdateExpense,
       deleteExpense: mockDeleteExpense,

--- a/src/components/ExpenseModal.tsx
+++ b/src/components/ExpenseModal.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useCategories } from '../hooks/useCategories'
 import { useTags } from '../hooks/useTags'
-import { useExpenses } from '../hooks/useExpenses'
+import { useExpenseMutations } from '../hooks/useExpenseMutations'
 import { PAYMENT_METHODS } from '../constants/paymentMethods'
 import type { Expense, Category, UpdateExpenseInput } from '../types'
 import './ExpenseModal.css'
@@ -24,7 +24,7 @@ export const ExpenseModal = ({
   const [formData, setFormData] = useState<UpdateExpenseInput>({})
   const [submitting, setSubmitting] = useState<boolean>(false)
   const { categories, loading: loadingCategories } = useCategories()
-  const { updateExpense, deleteExpense } = useExpenses(userId)
+  const { updateExpense, deleteExpense } = useExpenseMutations(userId)
 
   // 選択されたカテゴリーIDを取得
   const selectedCategoryId = categories.find(
@@ -68,8 +68,7 @@ export const ExpenseModal = ({
     if (
       !formData.date ||
       formData.amount === undefined ||
-      !formData.bigCategory ||
-      !formData.paymentMethod
+      !formData.bigCategory
     ) {
       alert('必須項目を入力してください')
       return
@@ -88,7 +87,7 @@ export const ExpenseModal = ({
         amount: amount,
         bigCategory: formData.bigCategory,
         tags: formData.tags,
-        paymentMethod: formData.paymentMethod,
+        paymentMethod: formData.paymentMethod ?? '',
         description: formData.description,
       })
 
@@ -206,16 +205,15 @@ export const ExpenseModal = ({
             </div>
 
             <div className="form-group">
-              <label htmlFor="modal-payment">支払い方法 <span className="required">*</span></label>
+              <label htmlFor="modal-payment">支払い方法（任意）</label>
               <select
                 id="modal-payment"
                 value={formData.paymentMethod || ''}
                 onChange={(e) =>
                   setFormData({ ...formData, paymentMethod: e.target.value })
                 }
-                required
               >
-                <option value="">選択してください</option>
+                <option value="">未選択</option>
                 {PAYMENT_METHODS.map((method) => (
                   <option key={method} value={method}>
                     {method}

--- a/src/components/Pagination.css
+++ b/src/components/Pagination.css
@@ -1,0 +1,80 @@
+.pagination {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem 0.75rem;
+  margin-top: 1.25rem;
+  padding-top: 1rem;
+  border-top: 1px solid #e2e8f0;
+}
+
+.pagination-nav {
+  padding: 0.45rem 0.85rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #334155;
+  background: #fff;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.pagination-nav:hover:not(:disabled) {
+  background: #f8fafc;
+  border-color: #94a3b8;
+}
+
+.pagination-nav:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.pagination-pages {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.pagination-page {
+  min-width: 2.25rem;
+  height: 2.25rem;
+  padding: 0 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #475569;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.pagination-page:hover {
+  background: #f1f5f9;
+  border-color: #cbd5e1;
+}
+
+.pagination-page--active {
+  color: #fff;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  border-color: transparent;
+}
+
+.pagination-page--active:hover {
+  color: #fff;
+  filter: brightness(1.05);
+}
+
+.pagination-ellipsis {
+  padding: 0 0.15rem;
+  color: #94a3b8;
+  font-weight: 600;
+  user-select: none;
+}

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,0 +1,57 @@
+import { buildPaginationItems } from '../utils/pagination'
+import './Pagination.css'
+
+interface PaginationProps {
+  currentPage: number
+  totalPages: number
+  onPageChange: (page: number) => void
+}
+
+export const Pagination = ({ currentPage, totalPages, onPageChange }: PaginationProps) => {
+  if (totalPages <= 1) {
+    return null
+  }
+
+  const items = buildPaginationItems(currentPage, totalPages)
+
+  return (
+    <nav className="pagination" aria-label="ページ送り">
+      <button
+        type="button"
+        className="pagination-nav"
+        disabled={currentPage <= 1}
+        onClick={() => onPageChange(currentPage - 1)}
+      >
+        前へ
+      </button>
+      <ol className="pagination-pages">
+        {items.map((item, index) =>
+          item === 'ellipsis' ? (
+            <li key={`ellipsis-${index}`} className="pagination-ellipsis" aria-hidden>
+              …
+            </li>
+          ) : (
+            <li key={item}>
+              <button
+                type="button"
+                className={`pagination-page${item === currentPage ? ' pagination-page--active' : ''}`}
+                onClick={() => onPageChange(item)}
+                aria-current={item === currentPage ? 'page' : undefined}
+              >
+                {item}
+              </button>
+            </li>
+          )
+        )}
+      </ol>
+      <button
+        type="button"
+        className="pagination-nav"
+        disabled={currentPage >= totalPages}
+        onClick={() => onPageChange(currentPage + 1)}
+      >
+        次へ
+      </button>
+    </nav>
+  )
+}

--- a/src/hooks/useDashboardExpenses.test.tsx
+++ b/src/hooks/useDashboardExpenses.test.tsx
@@ -1,0 +1,175 @@
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { Timestamp } from 'firebase/firestore'
+import {
+  useDashboardExpenses,
+  getCurrentYearMonth,
+  DASHBOARD_EXPENSE_PAGE_SIZE,
+} from './useDashboardExpenses'
+import { expenseService } from '../services/expenseService'
+import type { Expense } from '../types'
+
+vi.mock('../services/expenseService', () => ({
+  expenseService: {
+    getExpensesInMonth: vi.fn(),
+    getExpensesByUserId: vi.fn(),
+  },
+}))
+
+function makeExpense(id: string, amount: number): Expense {
+  const ts = Timestamp.fromDate(new Date('2026-03-15T12:00:00Z'))
+  return {
+    id,
+    date: ts,
+    amount,
+    userId: 'user-1',
+    bigCategory: '食費',
+    tags: '',
+    paymentMethod: '',
+    description: '',
+    createdAt: ts,
+    updatedAt: ts,
+  }
+}
+
+describe('getCurrentYearMonth', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns calendar year and 1-based month for mocked date', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-15T08:00:00Z'))
+    expect(getCurrentYearMonth()).toEqual({ year: 2026, month: 6 })
+  })
+})
+
+describe('useDashboardExpenses', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not fetch when userId is undefined', async () => {
+    const { result } = renderHook(() => useDashboardExpenses(undefined))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(expenseService.getExpensesInMonth).not.toHaveBeenCalled()
+    expect(result.current.expenses).toEqual([])
+    expect(result.current.monthExpenseCount).toBe(0)
+    expect(result.current.error).toBeNull()
+  })
+
+  it('loads month data via getExpensesInMonth and exposes monthExpenseCount', async () => {
+    const list = [makeExpense('a', 100), makeExpense('b', 200)]
+    vi.mocked(expenseService.getExpensesInMonth).mockResolvedValue(list)
+
+    const { result } = renderHook(() => useDashboardExpenses('user-1'))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    const ym = getCurrentYearMonth()
+    expect(expenseService.getExpensesInMonth).toHaveBeenCalledWith('user-1', ym.year, ym.month)
+    expect(result.current.monthExpenseCount).toBe(2)
+    expect(result.current.monthlyTotal).toBe(300)
+    expect(result.current.expenses).toHaveLength(2)
+    expect(result.current.error).toBeNull()
+    expect(expenseService.getExpensesByUserId).not.toHaveBeenCalled()
+  })
+
+  it('pages client-side with DASHBOARD_EXPENSE_PAGE_SIZE', async () => {
+    const list = Array.from({ length: 12 }, (_, i) => makeExpense(`id-${i}`, i + 1))
+    vi.mocked(expenseService.getExpensesInMonth).mockResolvedValue(list)
+
+    const { result } = renderHook(() => useDashboardExpenses('user-1'))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.expenses).toHaveLength(DASHBOARD_EXPENSE_PAGE_SIZE)
+    expect(result.current.totalPages).toBe(2)
+    expect(result.current.currentPage).toBe(1)
+
+    act(() => {
+      void result.current.goToPage(2)
+    })
+
+    expect(result.current.expenses).toHaveLength(2)
+    expect(result.current.currentPage).toBe(2)
+  })
+
+  it('sets error and clears data when getExpensesInMonth fails without calling getExpensesByUserId', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      vi.mocked(expenseService.getExpensesInMonth).mockRejectedValue(new Error('index required'))
+
+      const { result } = renderHook(() => useDashboardExpenses('user-1'))
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false)
+      })
+
+      expect(result.current.error?.message).toBe('index required')
+      expect(result.current.expenses).toEqual([])
+      expect(result.current.monthExpenseCount).toBe(0)
+      expect(result.current.monthlyTotal).toBe(0)
+      expect(expenseService.getExpensesByUserId).not.toHaveBeenCalled()
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
+
+  it('reloads when setSelectedYearMonth changes target month', async () => {
+    vi.mocked(expenseService.getExpensesInMonth).mockResolvedValue([])
+
+    const { result } = renderHook(() => useDashboardExpenses('user-1'))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    const initial = getCurrentYearMonth()
+    expect(expenseService.getExpensesInMonth).toHaveBeenCalledWith('user-1', initial.year, initial.month)
+
+    vi.mocked(expenseService.getExpensesInMonth).mockClear()
+
+    act(() => {
+      result.current.setSelectedYearMonth(2025, 1)
+    })
+
+    await waitFor(() => {
+      expect(expenseService.getExpensesInMonth).toHaveBeenCalledWith('user-1', 2025, 1)
+    })
+
+    expect(result.current.selectedYearMonth).toEqual({ year: 2025, month: 1 })
+  })
+
+  it('refreshAfterMutation reloads data', async () => {
+    vi.mocked(expenseService.getExpensesInMonth)
+      .mockResolvedValueOnce([makeExpense('x', 10)])
+      .mockResolvedValueOnce([makeExpense('x', 10), makeExpense('y', 20)])
+
+    const { result } = renderHook(() => useDashboardExpenses('user-1'))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.monthExpenseCount).toBe(1)
+
+    await act(async () => {
+      await result.current.refreshAfterMutation()
+    })
+
+    await waitFor(() => {
+      expect(result.current.monthExpenseCount).toBe(2)
+    })
+
+    expect(expenseService.getExpensesInMonth).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/hooks/useDashboardExpenses.ts
+++ b/src/hooks/useDashboardExpenses.ts
@@ -17,7 +17,7 @@ function sumAmounts(list: Expense[]): number {
 
 /**
  * ダッシュボードは選択した暦月の支出を表示。
- * 1) 月範囲クエリ（インデックス要）→ 失敗時 2) userId のみの取得（インデックス不要）＋クライアントでその月に絞る。
+ * Firestore は月範囲クエリ（userId + date）のみ使用。失敗時も userId 全件取得は行わずエラーにする（読み取り・無料枠対策）。
  * 合計は一覧と同じデータから算出（monthlyTotals ドキュメントに依存しない）。
  */
 export const useDashboardExpenses = (userId: string | undefined) => {
@@ -61,35 +61,24 @@ export const useDashboardExpenses = (userId: string | undefined) => {
       const cancelled = opts?.cancelled ?? (() => false)
       const { year, month } = yearMonth
 
-      let list: Expense[] = []
       try {
-        list = await expenseService.getExpensesInMonth(userId, year, month)
+        const list = await expenseService.getExpensesInMonth(userId, year, month)
         if (cancelled()) return
-      } catch (firstErr) {
-        console.warn('getExpensesInMonth failed, using userId-only fallback', firstErr)
-        try {
-          const all = await expenseService.getExpensesByUserId(userId)
-          if (cancelled()) return
-          list = expenseService.filterExpensesInCalendarMonth(all, year, month)
-        } catch (secondErr) {
-          if (!cancelled()) {
-            console.error(secondErr)
-            setError(secondErr as Error)
-            setMonthExpensesAll([])
-            setExpenses([])
-            setMonthlyTotal(0)
-            setTotalPages(1)
-            setCurrentPage(1)
-          }
-          return
+        setMonthExpensesAll(list)
+        setMonthlyTotal(sumAmounts(list))
+        applyClientPage(list, 1)
+        setError(null)
+      } catch (err) {
+        console.error('getExpensesInMonth failed (no broad-fetch fallback)', err)
+        if (!cancelled()) {
+          setError(err as Error)
+          setMonthExpensesAll([])
+          setExpenses([])
+          setMonthlyTotal(0)
+          setTotalPages(1)
+          setCurrentPage(1)
         }
       }
-
-      if (cancelled()) return
-      setMonthExpensesAll(list)
-      setMonthlyTotal(sumAmounts(list))
-      applyClientPage(list, 1)
-      setError(null)
     },
     [userId, yearMonth, applyClientPage]
   )

--- a/src/hooks/useDashboardExpenses.ts
+++ b/src/hooks/useDashboardExpenses.ts
@@ -1,0 +1,163 @@
+import { useState, useEffect, useCallback, useLayoutEffect, useRef } from 'react'
+import { expenseService } from '../services/expenseService'
+import type { Expense } from '../types'
+
+export const DASHBOARD_EXPENSE_PAGE_SIZE = 10
+
+export type DashboardYearMonth = { year: number; month: number }
+
+export function getCurrentYearMonth(): DashboardYearMonth {
+  const d = new Date()
+  return { year: d.getFullYear(), month: d.getMonth() + 1 }
+}
+
+function sumAmounts(list: Expense[]): number {
+  return list.reduce((s, e) => s + (e.amount || 0), 0)
+}
+
+/**
+ * ダッシュボードは選択した暦月の支出を表示。
+ * 1) 月範囲クエリ（インデックス要）→ 失敗時 2) userId のみの取得（インデックス不要）＋クライアントでその月に絞る。
+ * 合計は一覧と同じデータから算出（monthlyTotals ドキュメントに依存しない）。
+ */
+export const useDashboardExpenses = (userId: string | undefined) => {
+  const [yearMonth, setYearMonth] = useState<DashboardYearMonth>(getCurrentYearMonth)
+  const prevUserIdRef = useRef<string | undefined>(undefined)
+
+  useLayoutEffect(() => {
+    if (userId) {
+      if (prevUserIdRef.current !== undefined && prevUserIdRef.current !== userId) {
+        setYearMonth(getCurrentYearMonth())
+      }
+      prevUserIdRef.current = userId
+    } else {
+      prevUserIdRef.current = undefined
+    }
+  }, [userId])
+
+  const setSelectedYearMonth = useCallback((year: number, month: number) => {
+    setYearMonth({ year, month })
+  }, [])
+
+  const [expenses, setExpenses] = useState<Expense[]>([])
+  /** 選択月分の全件（ページ分割の元） */
+  const [monthExpensesAll, setMonthExpensesAll] = useState<Expense[]>([])
+  const [loading, setLoading] = useState(true)
+  const [monthlyTotal, setMonthlyTotal] = useState(0)
+  const [currentPage, setCurrentPage] = useState(1)
+  const [totalPages, setTotalPages] = useState(1)
+  const [error, setError] = useState<Error | null>(null)
+
+  const applyClientPage = useCallback((full: Expense[], page: number) => {
+    const start = (page - 1) * DASHBOARD_EXPENSE_PAGE_SIZE
+    setExpenses(full.slice(start, start + DASHBOARD_EXPENSE_PAGE_SIZE))
+    setCurrentPage(page)
+    setTotalPages(Math.max(1, Math.ceil(full.length / DASHBOARD_EXPENSE_PAGE_SIZE)))
+  }, [])
+
+  const loadDashboardMonthData = useCallback(
+    async (opts?: { cancelled?: () => boolean }) => {
+      if (!userId) return
+      const cancelled = opts?.cancelled ?? (() => false)
+      const { year, month } = yearMonth
+
+      let list: Expense[] = []
+      try {
+        list = await expenseService.getExpensesInMonth(userId, year, month)
+        if (cancelled()) return
+      } catch (firstErr) {
+        console.warn('getExpensesInMonth failed, using userId-only fallback', firstErr)
+        try {
+          const all = await expenseService.getExpensesByUserId(userId)
+          if (cancelled()) return
+          list = expenseService.filterExpensesInCalendarMonth(all, year, month)
+        } catch (secondErr) {
+          if (!cancelled()) {
+            console.error(secondErr)
+            setError(secondErr as Error)
+            setMonthExpensesAll([])
+            setExpenses([])
+            setMonthlyTotal(0)
+            setTotalPages(1)
+            setCurrentPage(1)
+          }
+          return
+        }
+      }
+
+      if (cancelled()) return
+      setMonthExpensesAll(list)
+      setMonthlyTotal(sumAmounts(list))
+      applyClientPage(list, 1)
+      setError(null)
+    },
+    [userId, yearMonth, applyClientPage]
+  )
+
+  const goToPage = useCallback(
+    (target: number) => {
+      if (monthExpensesAll.length === 0) {
+        if (target === 1) applyClientPage([], 1)
+        return
+      }
+      const maxPage = Math.max(1, Math.ceil(monthExpensesAll.length / DASHBOARD_EXPENSE_PAGE_SIZE))
+      const page = Math.min(Math.max(1, target), maxPage)
+      applyClientPage(monthExpensesAll, page)
+    },
+    [monthExpensesAll, applyClientPage]
+  )
+
+  const refreshAfterMutation = useCallback(async () => {
+    if (!userId) return
+    setLoading(true)
+    try {
+      await loadDashboardMonthData()
+    } finally {
+      setLoading(false)
+    }
+  }, [userId, loadDashboardMonthData])
+
+  useEffect(() => {
+    if (!userId) {
+      setMonthExpensesAll([])
+      setExpenses([])
+      setMonthlyTotal(0)
+      setLoading(false)
+      setCurrentPage(1)
+      setTotalPages(1)
+      setError(null)
+      return
+    }
+
+    let cancelled = false
+    const isCancelled = () => cancelled
+
+    setLoading(true)
+    setError(null)
+
+    void loadDashboardMonthData({ cancelled: isCancelled }).finally(() => {
+      if (!isCancelled()) setLoading(false)
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [userId, yearMonth, loadDashboardMonthData])
+
+  return {
+    expenses,
+    loading,
+    monthlyTotal,
+    /** 合計カードも一覧と同じロードに揃える */
+    monthlyLoading: loading,
+    currentPage,
+    totalPages,
+    goToPage,
+    refreshAfterMutation,
+    error,
+    /** 選択月に取得した支出の件数（ページング前の全件） */
+    monthExpenseCount: monthExpensesAll.length,
+    selectedYearMonth: yearMonth,
+    setSelectedYearMonth,
+  }
+}

--- a/src/hooks/useExpenseMutations.ts
+++ b/src/hooks/useExpenseMutations.ts
@@ -1,0 +1,30 @@
+import { useCallback } from 'react'
+import { expenseService } from '../services/expenseService'
+import type { CreateExpenseInput, UpdateExpenseInput } from '../types'
+
+/** 一覧取得を伴わない支出の作成・更新・削除（ダッシュボード等で利用） */
+export const useExpenseMutations = (userId: string | undefined) => {
+  const createExpense = useCallback(
+    async (input: CreateExpenseInput): Promise<string> => {
+      if (!userId) {
+        throw new Error('User ID is required')
+      }
+      return expenseService.createExpense(userId, input)
+    },
+    [userId]
+  )
+
+  const updateExpense = useCallback(async (expenseId: string, input: UpdateExpenseInput): Promise<void> => {
+    await expenseService.updateExpense(expenseId, input)
+  }, [])
+
+  const deleteExpense = useCallback(async (expenseId: string): Promise<void> => {
+    await expenseService.deleteExpense(expenseId)
+  }, [])
+
+  return {
+    createExpense,
+    updateExpense,
+    deleteExpense,
+  }
+}

--- a/src/hooks/useExpenses.ts
+++ b/src/hooks/useExpenses.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { expenseService } from '../services/expenseService'
 import { useExpenseMutations } from './useExpenseMutations'
 import type { Expense, CreateExpenseInput, UpdateExpenseInput } from '../types'
@@ -10,16 +10,19 @@ export const useExpenses = (userId: string | undefined) => {
   const [loading, setLoading] = useState<boolean>(true)
   const [error, setError] = useState<Error | null>(null)
 
-  useEffect(() => {
-    const fetchExpenses = async () => {
+  const loadExpensesFromServer = useCallback(
+    async (options: { withLoadingSpinner: boolean }) => {
       if (!userId) {
         setExpenses([])
+        setError(null)
         setLoading(false)
         return
       }
 
-      try {
+      if (options.withLoadingSpinner) {
         setLoading(true)
+      }
+      try {
         setError(null)
         const data = await expenseService.getExpensesByUserId(userId)
         setExpenses(data)
@@ -28,24 +31,21 @@ export const useExpenses = (userId: string | undefined) => {
         setError(e as Error)
         setExpenses([])
       } finally {
-        setLoading(false)
+        if (options.withLoadingSpinner) {
+          setLoading(false)
+        }
       }
-    }
+    },
+    [userId]
+  )
 
-    fetchExpenses()
-  }, [userId])
+  useEffect(() => {
+    void loadExpensesFromServer({ withLoadingSpinner: true })
+  }, [loadExpensesFromServer])
 
   const refreshExpenses = async () => {
     if (!userId) return
-
-    try {
-      const data = await expenseService.getExpensesByUserId(userId)
-      setExpenses(data)
-      setError(null)
-    } catch (e) {
-      console.error('Failed to refresh expenses', e)
-      setError(e as Error)
-    }
+    await loadExpensesFromServer({ withLoadingSpinner: false })
   }
 
   // 支出を作成

--- a/src/hooks/useExpenses.ts
+++ b/src/hooks/useExpenses.ts
@@ -1,8 +1,11 @@
 import { useState, useEffect } from 'react'
 import { expenseService } from '../services/expenseService'
+import { useExpenseMutations } from './useExpenseMutations'
 import type { Expense, CreateExpenseInput, UpdateExpenseInput } from '../types'
 
 export const useExpenses = (userId: string | undefined) => {
+  const { createExpense: createExpenseDoc, updateExpense: updateExpenseDoc, deleteExpense: deleteExpenseDoc } =
+    useExpenseMutations(userId)
   const [expenses, setExpenses] = useState<Expense[]>([])
   const [loading, setLoading] = useState<boolean>(true)
   const [error, setError] = useState<Error | null>(null)
@@ -52,7 +55,7 @@ export const useExpenses = (userId: string | undefined) => {
     }
 
     try {
-      const expenseId = await expenseService.createExpense(userId, input)
+      const expenseId = await createExpenseDoc(input)
       await refreshExpenses()
       return expenseId
     } catch (e) {
@@ -65,7 +68,7 @@ export const useExpenses = (userId: string | undefined) => {
   // 支出を更新
   const updateExpense = async (expenseId: string, input: UpdateExpenseInput): Promise<void> => {
     try {
-      await expenseService.updateExpense(expenseId, input)
+      await updateExpenseDoc(expenseId, input)
       await refreshExpenses()
     } catch (e) {
       console.error('Failed to update expense', e)
@@ -77,7 +80,7 @@ export const useExpenses = (userId: string | undefined) => {
   // 支出を削除
   const deleteExpense = async (expenseId: string): Promise<void> => {
     try {
-      await expenseService.deleteExpense(expenseId)
+      await deleteExpenseDoc(expenseId)
       await refreshExpenses()
     } catch (e) {
       console.error('Failed to delete expense', e)

--- a/src/pages/Dashboard/Dashboard.css
+++ b/src/pages/Dashboard/Dashboard.css
@@ -133,6 +133,9 @@
 }
 
 .dashboard-list-error {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
   margin: 0 0 0.75rem;
   padding: 0.75rem 1rem;
   font-size: 0.875rem;
@@ -140,6 +143,17 @@
   background: #fef2f2;
   border-radius: 0.5rem;
   border: 1px solid #fecaca;
+}
+
+.dashboard-list-error-summary {
+  line-height: 1.5;
+}
+
+.dashboard-list-error-detail {
+  font-size: 0.8125rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  word-break: break-word;
+  color: #7f1d1d;
 }
 
 .welcome-section,

--- a/src/pages/Dashboard/Dashboard.css
+++ b/src/pages/Dashboard/Dashboard.css
@@ -95,6 +95,53 @@
   line-height: 1.6;
 }
 
+.expenses-section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem 1rem;
+  margin-bottom: 0.25rem;
+}
+
+.expenses-section-heading-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem 1rem;
+}
+
+.expenses-section-heading-row h2 {
+  margin: 0;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.expenses-section-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem 1rem;
+  flex-shrink: 0;
+}
+
+.dashboard-expense-count {
+  margin: 0;
+  font-size: 0.875rem;
+  color: #64748b;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.dashboard-list-error {
+  margin: 0 0 0.75rem;
+  padding: 0.75rem 1rem;
+  font-size: 0.875rem;
+  color: #b91c1c;
+  background: #fef2f2;
+  border-radius: 0.5rem;
+  border: 1px solid #fecaca;
+}
+
 .welcome-section,
 .category-tag-section,
 .expense-form-section,
@@ -112,7 +159,49 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
   margin-bottom: 1rem;
+}
+
+.dashboard-year-month-picker {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem 0.5rem;
+  flex-shrink: 0;
+}
+
+.dashboard-year-month-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #64748b;
+  margin: 0;
+}
+
+.dashboard-year-month-select {
+  padding: 0.5rem 0.65rem;
+  border-radius: 0.5rem;
+  border: 1px solid #e2e8f0;
+  background-color: #fff;
+  color: #0f172a;
+  font-weight: 600;
+  font-size: 0.9rem;
+  font-family: inherit;
+  cursor: pointer;
+  min-width: 4.5rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.dashboard-year-month-select:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.12);
+}
+
+.dashboard-year-month-select option {
+  color: #0f172a;
+  background-color: #fff;
 }
 
 .monthly-summary-section h2 {
@@ -639,6 +728,15 @@
   .expenses-table th:nth-child(n+6),
   .expenses-table td:nth-child(n+6) {
     display: none;
+  }
+
+  .expenses-section-heading-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .dashboard-year-month-picker {
+    justify-content: flex-start;
   }
 
   .expense-form-header {

--- a/src/pages/Dashboard/Dashboard.test.tsx
+++ b/src/pages/Dashboard/Dashboard.test.tsx
@@ -2,13 +2,19 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '../../test/testUtils'
 import Dashboard from './Dashboard'
 import { useAuth } from '../../context/AuthContext'
-import { useExpenses } from '../../hooks/useExpenses'
+import { useDashboardExpenses } from '../../hooks/useDashboardExpenses'
 import { useUserName } from '../../hooks/useUserName'
 import type { User } from 'firebase/auth'
 
 // モック
 vi.mock('../../context/AuthContext')
-vi.mock('../../hooks/useExpenses')
+vi.mock('../../hooks/useDashboardExpenses', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../../hooks/useDashboardExpenses')>()
+  return {
+    ...mod,
+    useDashboardExpenses: vi.fn(),
+  }
+})
 vi.mock('../../hooks/useUserName')
 vi.mock('../../components/ExpenseForm', () => ({
   ExpenseForm: () => <div data-testid="expense-form">Expense Form</div>,
@@ -47,6 +53,24 @@ const mockUser = {
   toJSON: vi.fn(),
 } as unknown as User
 
+const defaultDashboardExpensesMock = {
+  expenses: [],
+  loading: false,
+  monthlyTotal: 0,
+  monthlyLoading: false,
+  currentPage: 1,
+  totalPages: 1,
+  goToPage: vi.fn(),
+  refreshAfterMutation: vi.fn(),
+  error: null,
+  monthExpenseCount: 0,
+  get selectedYearMonth() {
+    const d = new Date()
+    return { year: d.getFullYear(), month: d.getMonth() + 1 }
+  },
+  setSelectedYearMonth: vi.fn(),
+}
+
 describe('Dashboard', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -62,15 +86,7 @@ describe('Dashboard', () => {
       displayName: 'Test User',
       loading: false,
     })
-    vi.mocked(useExpenses).mockReturnValue({
-      expenses: [],
-      loading: false,
-      error: null,
-      refreshExpenses: vi.fn(),
-      createExpense: vi.fn(),
-      updateExpense: vi.fn(),
-      deleteExpense: vi.fn(),
-    })
+    vi.mocked(useDashboardExpenses).mockReturnValue({ ...defaultDashboardExpensesMock })
 
     render(<Dashboard />)
 
@@ -89,21 +105,17 @@ describe('Dashboard', () => {
       displayName: null,
       loading: true,
     })
-    vi.mocked(useExpenses).mockReturnValue({
-      expenses: [],
+    vi.mocked(useDashboardExpenses).mockReturnValue({
+      ...defaultDashboardExpensesMock,
       loading: true,
-      error: null,
-      refreshExpenses: vi.fn(),
-      createExpense: vi.fn(),
-      updateExpense: vi.fn(),
-      deleteExpense: vi.fn(),
+      monthlyLoading: true,
     })
 
     render(<Dashboard />)
 
     // 読み込み中…が複数あるので、より具体的なクエリを使用
     expect(screen.getAllByText('読み込み中…').length).toBeGreaterThan(0)
-    expect(screen.getByText('読み込み中...')).toBeInTheDocument()
+    expect(screen.getAllByText('読み込み中...').length).toBeGreaterThan(0)
   })
 
   it('should display monthly total', () => {
@@ -116,15 +128,7 @@ describe('Dashboard', () => {
       displayName: 'Test User',
       loading: false,
     })
-    vi.mocked(useExpenses).mockReturnValue({
-      expenses: [],
-      loading: false,
-      error: null,
-      refreshExpenses: vi.fn(),
-      createExpense: vi.fn(),
-      updateExpense: vi.fn(),
-      deleteExpense: vi.fn(),
-    })
+    vi.mocked(useDashboardExpenses).mockReturnValue({ ...defaultDashboardExpensesMock })
 
     render(<Dashboard />)
 
@@ -143,15 +147,7 @@ describe('Dashboard', () => {
       displayName: 'Test User',
       loading: false,
     })
-    vi.mocked(useExpenses).mockReturnValue({
-      expenses: [],
-      loading: false,
-      error: null,
-      refreshExpenses: vi.fn(),
-      createExpense: vi.fn(),
-      updateExpense: vi.fn(),
-      deleteExpense: vi.fn(),
-    })
+    vi.mocked(useDashboardExpenses).mockReturnValue({ ...defaultDashboardExpensesMock })
 
     render(<Dashboard />)
 
@@ -173,15 +169,7 @@ describe('Dashboard', () => {
       displayName: 'Test User',
       loading: false,
     })
-    vi.mocked(useExpenses).mockReturnValue({
-      expenses: [],
-      loading: false,
-      error: null,
-      refreshExpenses: vi.fn(),
-      createExpense: vi.fn(),
-      updateExpense: vi.fn(),
-      deleteExpense: vi.fn(),
-    })
+    vi.mocked(useDashboardExpenses).mockReturnValue({ ...defaultDashboardExpensesMock })
 
     render(<Dashboard />)
 

--- a/src/pages/Dashboard/Dashboard.test.tsx
+++ b/src/pages/Dashboard/Dashboard.test.tsx
@@ -159,6 +159,75 @@ describe('Dashboard', () => {
     })
   })
 
+  it('should render year and month selectors and expense count', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: mockUser,
+      loading: false,
+      signOutUser: vi.fn(),
+    })
+    vi.mocked(useUserName).mockReturnValue({
+      displayName: 'Test User',
+      loading: false,
+    })
+    vi.mocked(useDashboardExpenses).mockReturnValue({
+      ...defaultDashboardExpensesMock,
+      monthExpenseCount: 5,
+    })
+
+    render(<Dashboard />)
+
+    expect(screen.getByRole('group', { name: '表示する年月' })).toBeInTheDocument()
+    expect(screen.getByLabelText('年')).toBeInTheDocument()
+    expect(screen.getByLabelText('月')).toBeInTheDocument()
+    expect(screen.getByText('5件')).toBeInTheDocument()
+  })
+
+  it('should call setSelectedYearMonth when year select changes', async () => {
+    const setSelectedYearMonth = vi.fn()
+    const userEvent = (await import('@testing-library/user-event')).default.setup()
+
+    vi.mocked(useAuth).mockReturnValue({
+      user: mockUser,
+      loading: false,
+      signOutUser: vi.fn(),
+    })
+    vi.mocked(useUserName).mockReturnValue({
+      displayName: 'Test User',
+      loading: false,
+    })
+    vi.mocked(useDashboardExpenses).mockReturnValue({
+      ...defaultDashboardExpensesMock,
+      setSelectedYearMonth,
+      selectedYearMonth: { year: 2026, month: 4 },
+    })
+
+    render(<Dashboard />)
+
+    await userEvent.selectOptions(screen.getByLabelText('年'), '2024')
+    expect(setSelectedYearMonth).toHaveBeenCalledWith(2024, 4)
+  })
+
+  it('should show list error summary and detail message', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: mockUser,
+      loading: false,
+      signOutUser: vi.fn(),
+    })
+    vi.mocked(useUserName).mockReturnValue({
+      displayName: 'Test User',
+      loading: false,
+    })
+    vi.mocked(useDashboardExpenses).mockReturnValue({
+      ...defaultDashboardExpensesMock,
+      error: new Error('failed-precondition: missing index'),
+    })
+
+    render(<Dashboard />)
+
+    expect(screen.getByText(/支出一覧の取得に失敗しました/)).toBeInTheDocument()
+    expect(screen.getByText(/failed-precondition: missing index/)).toBeInTheDocument()
+  })
+
   it('should render links correctly', () => {
     vi.mocked(useAuth).mockReturnValue({
       user: mockUser,

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -1,45 +1,63 @@
 import { useState, useMemo } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
 import { useAuth } from '../../context/AuthContext'
-import { useExpenses } from '../../hooks/useExpenses'
+import {
+  useDashboardExpenses,
+  getCurrentYearMonth,
+  type DashboardYearMonth,
+} from '../../hooks/useDashboardExpenses'
 import { useUserName } from '../../hooks/useUserName'
 import { ExpenseForm } from '../../components/ExpenseForm'
 import { ExpensesTable } from '../../components/ExpensesTable'
 import { ExpenseModal } from '../../components/ExpenseModal'
+import { Pagination } from '../../components/Pagination'
 import type { Expense } from '../../types'
 import './Dashboard.css'
+
+function isSameCalendarMonth(a: DashboardYearMonth, b: DashboardYearMonth): boolean {
+  return a.year === b.year && a.month === b.month
+}
 
 const Dashboard = () => {
   const { user, signOutUser } = useAuth()
   const navigate = useNavigate()
   const { displayName, loading: loadingName } = useUserName(user)
 
-  // カスタムフックを使用してデータを取得
-  const { expenses, loading: loadingExpenses, refreshExpenses } = useExpenses(user?.uid)
+  const {
+    expenses,
+    loading: loadingExpenses,
+    monthlyTotal,
+    monthlyLoading,
+    currentPage: expenseListPage,
+    totalPages: expenseListTotalPages,
+    goToPage,
+    refreshAfterMutation,
+    error: dashboardListError,
+    monthExpenseCount,
+    selectedYearMonth,
+    setSelectedYearMonth,
+  } = useDashboardExpenses(user?.uid)
 
-  // フォームの表示状態
+  const isViewingCurrentMonth = isSameCalendarMonth(selectedYearMonth, getCurrentYearMonth())
+
+  const yearOptions = useMemo(() => {
+    const cy = new Date().getFullYear()
+    const y = selectedYearMonth.year
+    const from = Math.min(y, cy - 10)
+    const to = Math.max(y, cy + 1)
+    return Array.from({ length: to - from + 1 }, (_, i) => from + i)
+  }, [selectedYearMonth.year])
+
+  const monthHeading = isViewingCurrentMonth
+    ? '今月の支出'
+    : `${selectedYearMonth.year}年${selectedYearMonth.month}月の支出`
+
+  const expenseListHeading = isViewingCurrentMonth
+    ? '今月の支出一覧'
+    : `${selectedYearMonth.year}年${selectedYearMonth.month}月の支出一覧`
+
   const [showForm, setShowForm] = useState<boolean>(false)
-
-  // モーダルの状態
   const [selectedExpense, setSelectedExpense] = useState<Expense | null>(null)
-
-  // 今月の合計金額を計算
-  const monthlyTotal = useMemo(() => {
-    const now = new Date()
-    const currentYear = now.getFullYear()
-    const currentMonth = now.getMonth()
-
-    return expenses
-      .filter((expense) => {
-        if (!expense.date) return false
-        const expenseDate = expense.date.toDate()
-        return (
-          expenseDate.getFullYear() === currentYear &&
-          expenseDate.getMonth() === currentMonth
-        )
-      })
-      .reduce((sum, expense) => sum + (expense.amount || 0), 0)
-  }, [expenses])
 
   const handleSignOut = async () => {
     try {
@@ -52,8 +70,7 @@ const Dashboard = () => {
 
   const handleExpenseSuccess = async () => {
     setShowForm(false)
-    // 支出一覧を即座に更新
-    await refreshExpenses()
+    await refreshAfterMutation()
   }
 
   const handleExpenseClick = (expense: Expense) => {
@@ -65,12 +82,15 @@ const Dashboard = () => {
   }
 
   const handleExpenseUpdate = async () => {
-    await refreshExpenses()
+    await refreshAfterMutation()
   }
 
   const handleExpenseDelete = async () => {
-    await refreshExpenses()
+    await refreshAfterMutation()
   }
+
+  const listBusy = loadingExpenses
+  const summaryBusy = monthlyLoading
 
   return (
     <div className="dashboard-page">
@@ -92,7 +112,7 @@ const Dashboard = () => {
       <main className="dashboard-content">
         <section className="dashboard-card monthly-summary-section">
           <div className="monthly-summary-header">
-            <h2>今月の支出</h2>
+            <h2>{monthHeading}</h2>
             <div className="monthly-summary-links">
               <Link to="/monthly-summary" className="monthly-summary-link">
                 月毎のサマリー →
@@ -103,7 +123,7 @@ const Dashboard = () => {
             </div>
           </div>
           <div className="monthly-total">
-            {loadingExpenses ? (
+            {summaryBusy ? (
               <p className="loading-text">読み込み中...</p>
             ) : (
               <>
@@ -111,7 +131,9 @@ const Dashboard = () => {
                   ¥{monthlyTotal.toLocaleString()}
                 </span>
                 <p className="monthly-total-label">
-                  {new Date().getMonth() + 1}月の合計金額
+                  {isViewingCurrentMonth
+                    ? `${selectedYearMonth.month}月の合計金額`
+                    : `${selectedYearMonth.year}年${selectedYearMonth.month}月の合計金額`}
                 </p>
               </>
             )}
@@ -122,6 +144,7 @@ const Dashboard = () => {
           <div className="expense-form-header">
             <h2>支出を登録</h2>
             <button
+              type="button"
               className="toggle-form-button"
               onClick={() => setShowForm(!showForm)}
             >
@@ -135,11 +158,71 @@ const Dashboard = () => {
         </section>
 
         <section className="dashboard-card expenses-section">
-          <h2>支出一覧</h2>
+          <div className="expenses-section-header">
+            <div className="expenses-section-heading-row">
+              <h2>{expenseListHeading}</h2>
+              <div className="expenses-section-controls">
+                <div
+                  className="dashboard-year-month-picker"
+                  role="group"
+                  aria-label="表示する年月"
+                >
+                  <label htmlFor="dashboard-year-select" className="dashboard-year-month-label">
+                    年
+                  </label>
+                  <select
+                    id="dashboard-year-select"
+                    className="dashboard-year-month-select"
+                    value={selectedYearMonth.year}
+                    onChange={(e) =>
+                      setSelectedYearMonth(Number(e.target.value), selectedYearMonth.month)
+                    }
+                  >
+                    {yearOptions.map((y) => (
+                      <option key={y} value={y}>
+                        {y}
+                      </option>
+                    ))}
+                  </select>
+                  <label htmlFor="dashboard-month-select" className="dashboard-year-month-label">
+                    月
+                  </label>
+                  <select
+                    id="dashboard-month-select"
+                    className="dashboard-year-month-select"
+                    value={selectedYearMonth.month}
+                    onChange={(e) =>
+                      setSelectedYearMonth(selectedYearMonth.year, Number(e.target.value))
+                    }
+                  >
+                    {Array.from({ length: 12 }, (_, i) => i + 1).map((m) => (
+                      <option key={m} value={m}>
+                        {m}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <span className="dashboard-expense-count" aria-live="polite">
+                  {listBusy ? '読み込み中…' : `${monthExpenseCount}件`}
+                </span>
+              </div>
+            </div>
+          </div>
+          {dashboardListError && (
+            <p className="dashboard-list-error" role="alert">
+              支出一覧の取得に失敗しました。Firestore の複合インデックス（expenses: userId +
+              date）が作成されているか確認してください。
+            </p>
+          )}
           <ExpensesTable
             expenses={expenses}
-            loading={loadingExpenses}
+            loading={listBusy}
             onExpenseClick={handleExpenseClick}
+          />
+          <Pagination
+            currentPage={expenseListPage}
+            totalPages={expenseListTotalPages}
+            onPageChange={(p) => void goToPage(p)}
           />
         </section>
       </main>

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -1,22 +1,15 @@
 import { useState, useMemo } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
 import { useAuth } from '../../context/AuthContext'
-import {
-  useDashboardExpenses,
-  getCurrentYearMonth,
-  type DashboardYearMonth,
-} from '../../hooks/useDashboardExpenses'
+import { useDashboardExpenses, getCurrentYearMonth } from '../../hooks/useDashboardExpenses'
 import { useUserName } from '../../hooks/useUserName'
 import { ExpenseForm } from '../../components/ExpenseForm'
 import { ExpensesTable } from '../../components/ExpensesTable'
 import { ExpenseModal } from '../../components/ExpenseModal'
 import { Pagination } from '../../components/Pagination'
+import { buildDashboardYearOptions, isSameYearMonth } from '../../utils/dashboardYearMonth'
 import type { Expense } from '../../types'
 import './Dashboard.css'
-
-function isSameCalendarMonth(a: DashboardYearMonth, b: DashboardYearMonth): boolean {
-  return a.year === b.year && a.month === b.month
-}
 
 const Dashboard = () => {
   const { user, signOutUser } = useAuth()
@@ -38,15 +31,12 @@ const Dashboard = () => {
     setSelectedYearMonth,
   } = useDashboardExpenses(user?.uid)
 
-  const isViewingCurrentMonth = isSameCalendarMonth(selectedYearMonth, getCurrentYearMonth())
+  const isViewingCurrentMonth = isSameYearMonth(selectedYearMonth, getCurrentYearMonth())
 
-  const yearOptions = useMemo(() => {
-    const cy = new Date().getFullYear()
-    const y = selectedYearMonth.year
-    const from = Math.min(y, cy - 10)
-    const to = Math.max(y, cy + 1)
-    return Array.from({ length: to - from + 1 }, (_, i) => from + i)
-  }, [selectedYearMonth.year])
+  const yearOptions = useMemo(
+    () => buildDashboardYearOptions(selectedYearMonth.year),
+    [selectedYearMonth.year]
+  )
 
   const monthHeading = isViewingCurrentMonth
     ? '今月の支出'

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -210,8 +210,13 @@ const Dashboard = () => {
           </div>
           {dashboardListError && (
             <p className="dashboard-list-error" role="alert">
-              支出一覧の取得に失敗しました。Firestore の複合インデックス（expenses: userId +
-              date）が作成されているか確認してください。
+              <span className="dashboard-list-error-summary">
+                支出一覧の取得に失敗しました。Firestore に複合インデックス（collection: expenses、フィールド:
+                userId と date、並び: date 降順）が有効か確認してください。読み取り回数の抑制のため、全件取得フォールバックは行いません。
+              </span>
+              {dashboardListError.message ? (
+                <span className="dashboard-list-error-detail">{dashboardListError.message}</span>
+              ) : null}
             </p>
           )}
           <ExpensesTable

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -14,7 +14,6 @@ const Home = () => {
   const [isTesting, setIsTesting] = useState(false)
 
   const runTests = async () => {
-    console.log('テスト開始')
     setIsTesting(true)
     const results: TestResult[] = []
 
@@ -79,7 +78,6 @@ const Home = () => {
     setTestResults([...results])
 
     setIsTesting(false)
-    console.log('テスト完了')
   }
 
   useEffect(() => {
@@ -115,8 +113,7 @@ const Home = () => {
         <button
           className="home-test-button"
           onClick={() => {
-            console.log('ボタンクリック')
-            runTests()
+            void runTests()
           }}
           disabled={isTesting}
         >

--- a/src/pages/MonthlyExpenses/MonthlyExpenses.tsx
+++ b/src/pages/MonthlyExpenses/MonthlyExpenses.tsx
@@ -25,9 +25,11 @@ const MonthlyExpenses = () => {
   const currentYear = now.getFullYear()
   const currentMonth = now.getMonth() + 1 // getMonth()は0-11を返すため+1
 
-  // URLクエリパラメータから年月を取得
+  // URLクエリパラメータから年月・カテゴリーを取得
   const urlYear = searchParams.get('year')
   const urlMonth = searchParams.get('month')
+  const urlCategory = searchParams.get('category')
+  const urlTag = searchParams.get('tag')
 
   // 検索条件の状態（URLパラメータがあればそれを使用、なければ現在の年月）
   const [selectedYear, setSelectedYear] = useState<number | null>(
@@ -36,8 +38,8 @@ const MonthlyExpenses = () => {
   const [selectedMonth, setSelectedMonth] = useState<number | null>(
     urlMonth ? Number(urlMonth) : currentMonth
   )
-  const [selectedCategory, setSelectedCategory] = useState<string>('')
-  const [selectedTag, setSelectedTag] = useState<string>('')
+  const [selectedCategory, setSelectedCategory] = useState<string>(() => urlCategory ?? '')
+  const [selectedTag, setSelectedTag] = useState<string>(() => urlTag ?? '')
   const [selectedPaymentMethods, setSelectedPaymentMethods] = useState<string[]>([])
 
   // 選択されたカテゴリーに基づいてタグをフィルタリング
@@ -57,7 +59,10 @@ const MonthlyExpenses = () => {
   }, [selectedCategory, categories, allTags])
 
   // 検索セクションの折りたたみ状態（URLパラメータがある場合は折りたたむ）
-  const [isSearchExpanded, setIsSearchExpanded] = useState<boolean>(!urlYear && !urlMonth)
+  const [isSearchExpanded, setIsSearchExpanded] = useState<boolean>(
+    () =>
+      !urlYear && !urlMonth && !searchParams.has('category') && !searchParams.has('tag')
+  )
 
   // URLパラメータが変更されたときに状態を更新
   useEffect(() => {
@@ -67,11 +72,21 @@ const MonthlyExpenses = () => {
     if (urlMonth) {
       setSelectedMonth(Number(urlMonth))
     }
+    if (searchParams.has('category')) {
+      setSelectedCategory(searchParams.get('category') || '')
+    } else {
+      setSelectedCategory('')
+    }
+    if (searchParams.has('tag')) {
+      setSelectedTag(searchParams.get('tag') || '')
+    } else {
+      setSelectedTag('')
+    }
     // URLパラメータがある場合は検索セクションを折りたたむ
-    if (urlYear || urlMonth) {
+    if (urlYear || urlMonth || searchParams.has('category') || searchParams.has('tag')) {
       setIsSearchExpanded(false)
     }
-  }, [urlYear, urlMonth])
+  }, [urlYear, urlMonth, searchParams])
 
   // 選択した条件で支出をフィルタリング
   const filteredExpenses = useMemo(() => {

--- a/src/pages/MonthlySummary/MonthlySummary.css
+++ b/src/pages/MonthlySummary/MonthlySummary.css
@@ -178,13 +178,229 @@
 }
 
 .line-chart-section h2 {
+  margin-bottom: 0;
+}
+
+.monthly-section-heading {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
   margin-bottom: 1rem;
 }
 
+.monthly-section-heading h2 {
+  margin: 0;
+}
+
+.chart-group-toggle {
+  display: inline-flex;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  background: #f8fafc;
+}
+
+.chart-group-toggle-btn {
+  padding: 0.45rem 1rem;
+  border: none;
+  background: transparent;
+  color: #64748b;
+  font-weight: 600;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.chart-group-toggle-btn:hover {
+  background: #f1f5f9;
+  color: #0f172a;
+}
+
+.chart-group-toggle-btn.active {
+  background: #667eea;
+  color: #fff;
+}
+
+.chart-group-toggle-btn + .chart-group-toggle-btn {
+  border-left: 1px solid #e2e8f0;
+}
+
+.chart-group-toggle-btn.active + .chart-group-toggle-btn,
+.chart-group-toggle-btn + .chart-group-toggle-btn.active {
+  border-left-color: transparent;
+}
+
+/* 見出し・切替行とグラフの間（カテゴリー／タグどちらも同じ） */
 .line-chart-container {
-  margin-top: 0;
+  margin-top: 100px;
   width: 100%;
   height: 300px;
+}
+
+.line-chart-container--with-legend {
+  height: 380px;
+}
+
+.line-chart-tag-picker {
+  margin-top: 1rem;
+}
+
+.line-chart-tag-picker-fieldset {
+  border: 1px solid #e2e8f0;
+  border-radius: 0.5rem;
+  padding: 0.75rem 1rem 1rem;
+  margin: 0;
+  background: #f8fafc;
+}
+
+.line-chart-tag-picker-legend {
+  padding: 0 0.35rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #334155;
+}
+
+.line-chart-tag-picker-hint {
+  margin: 0 0 0.75rem;
+  font-size: 0.8rem;
+  color: #64748b;
+  line-height: 1.45;
+}
+
+.line-chart-tag-picker-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.line-chart-tag-filter-wrap {
+  flex: 1 1 12rem;
+  min-width: 0;
+  display: block;
+}
+
+.line-chart-tag-filter-sr-label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.line-chart-tag-filter-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.45rem 0.65rem;
+  font-size: 0.875rem;
+  color: #0f172a;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.375rem;
+  background: #fff;
+}
+
+.line-chart-tag-filter-input:focus {
+  outline: none;
+  border-color: #667eea;
+  box-shadow: 0 0 0 2px rgba(102, 126, 234, 0.25);
+}
+
+.line-chart-tag-filter-clear {
+  padding: 0.4rem 0.65rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #64748b;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.375rem;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.line-chart-tag-filter-clear:hover {
+  background: #f1f5f9;
+  color: #0f172a;
+}
+
+.line-chart-tag-picker-reset {
+  padding: 0.4rem 0.75rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #475569;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.375rem;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.line-chart-tag-picker-reset:hover {
+  background: #f1f5f9;
+  border-color: #cbd5e1;
+}
+
+.line-chart-tag-picker-count {
+  margin: 0 0 0.5rem;
+  font-size: 0.75rem;
+  color: #94a3b8;
+}
+
+.line-chart-tag-checkboxes-scroll {
+  max-height: min(280px, 45vh);
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 0.6rem 0.65rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.375rem;
+  background: #fff;
+  scrollbar-gutter: stable;
+}
+
+.line-chart-tag-filter-empty {
+  margin: 0;
+  padding: 0.75rem 0.25rem;
+  font-size: 0.85rem;
+  color: #94a3b8;
+  text-align: center;
+}
+
+.line-chart-tag-checkboxes {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(10.5rem, 1fr));
+  gap: 0.4rem 0.75rem;
+  align-content: start;
+}
+
+.line-chart-tag-checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  min-width: 0;
+  font-size: 0.8rem;
+  color: #334155;
+  cursor: pointer;
+  user-select: none;
+}
+
+.line-chart-tag-checkbox-label input {
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
+.line-chart-tag-checkbox-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 }
 
 /* 月毎の一覧セクション */

--- a/src/pages/MonthlySummary/MonthlySummary.test.tsx
+++ b/src/pages/MonthlySummary/MonthlySummary.test.tsx
@@ -10,6 +10,23 @@ import type { User } from 'firebase/auth'
 vi.mock('../../context/AuthContext')
 vi.mock('../../hooks/useExpenses')
 vi.mock('../../hooks/useUserName')
+vi.mock('../../hooks/useCategories', () => ({
+  useCategories: () => ({
+    categories: [],
+    loading: false,
+    error: null,
+    refreshCategories: vi.fn(),
+  }),
+}))
+vi.mock('../../hooks/useTags', () => ({
+  useTags: () => ({
+    allTags: [],
+    filteredTags: [],
+    loading: false,
+    error: null,
+    refreshTags: vi.fn(),
+  }),
+}))
 vi.mock('recharts', () => ({
   PieChart: ({ children }: { children: React.ReactNode }) => <div data-testid="pie-chart">{children}</div>,
   Pie: () => null,

--- a/src/pages/MonthlySummary/MonthlySummary.tsx
+++ b/src/pages/MonthlySummary/MonthlySummary.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
 import {
   PieChart,
@@ -11,9 +11,12 @@ import {
   XAxis,
   YAxis,
   CartesianGrid,
+  Legend,
 } from 'recharts'
 import { useAuth } from '../../context/AuthContext'
+import { useCategories } from '../../hooks/useCategories'
 import { useExpenses } from '../../hooks/useExpenses'
+import { useTags } from '../../hooks/useTags'
 import { useUserName } from '../../hooks/useUserName'
 import './MonthlySummary.css'
 
@@ -23,6 +26,16 @@ interface MonthlyData {
   total: number
   count: number
   categoryBreakdown: Record<string, number>
+  /** 複数タグは金額を等分して按分 */
+  tagBreakdown: Record<string, number>
+}
+
+/** 折れ線（タグ）の初期表示件数（この順位から「タグなし」は含めない） */
+const DEFAULT_LINE_TAG_COUNT = 5
+const TAG_NONE_LABEL = 'タグなし'
+
+function parseExpenseTags(tags: string): string[] {
+  return tags.split(', ').map((t) => t.trim()).filter(Boolean)
 }
 
 const MonthlySummary = () => {
@@ -30,6 +43,18 @@ const MonthlySummary = () => {
   const navigate = useNavigate()
   const { displayName, loading: loadingName } = useUserName(user)
   const { expenses, loading: loadingExpenses } = useExpenses(user?.uid)
+  const { categories } = useCategories()
+  const { allTags } = useTags()
+
+  /** タグ名 → 紐づくカテゴリー名（支出検索のドロップダウンと一致させる） */
+  const categoryNameByTagName = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const tag of allTags) {
+      const cat = categories.find((c) => c.id === tag.categoryId)
+      if (cat) map.set(tag.name, cat.name)
+    }
+    return map
+  }, [allTags, categories])
 
   // 月毎のデータを集計
   const monthlyData = useMemo(() => {
@@ -50,16 +75,28 @@ const MonthlySummary = () => {
           total: 0,
           count: 0,
           categoryBreakdown: {},
+          tagBreakdown: {},
         })
       }
 
       const data = dataMap.get(key)!
-      data.total += expense.amount || 0
+      const amount = expense.amount || 0
+      data.total += amount
       data.count += 1
 
-      // カテゴリー別の集計
       const category = expense.bigCategory || '未分類'
-      data.categoryBreakdown[category] = (data.categoryBreakdown[category] || 0) + (expense.amount || 0)
+      data.categoryBreakdown[category] = (data.categoryBreakdown[category] || 0) + amount
+
+      const tagLabels = parseExpenseTags(expense.tags || '')
+      if (tagLabels.length === 0) {
+        const tk = TAG_NONE_LABEL
+        data.tagBreakdown[tk] = (data.tagBreakdown[tk] || 0) + amount
+      } else {
+        const share = amount / tagLabels.length
+        tagLabels.forEach((t) => {
+          data.tagBreakdown[t] = (data.tagBreakdown[t] || 0) + share
+        })
+      }
     })
 
     // 配列に変換してソート（新しい順）
@@ -89,6 +126,99 @@ const MonthlySummary = () => {
       }))
   }, [monthlyData])
 
+  /** 円グラフ・折れ線の「カテゴリー / タグ」切り替え */
+  const [chartGroupBy, setChartGroupBy] = useState<'category' | 'tag'>('category')
+
+  /** 折れ線で選べるタグ一覧（全期間の合計が大きい順） */
+  const availableTagsForLine = useMemo(() => {
+    const tagTotals = new Map<string, number>()
+    monthlyData.forEach((m) => {
+      Object.entries(m.tagBreakdown).forEach(([t, v]) => {
+        tagTotals.set(t, (tagTotals.get(t) || 0) + v)
+      })
+    })
+    return Array.from(tagTotals.entries())
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0], 'ja'))
+      .map(([t]) => t)
+  }, [monthlyData])
+
+  /** 折れ線の既定「上位N件」用。金額順だがタグなしは対象外（一覧チェックボックスには残す） */
+  const tagsForDefaultLineChart = useMemo(
+    () => availableTagsForLine.filter((t) => t !== TAG_NONE_LABEL),
+    [availableTagsForLine]
+  )
+
+  /**
+   * 'default' … 上位 DEFAULT_LINE_TAG_COUNT 件を表示（タグなし除く）
+   * 配列 … ユーザーがチェックで選んだタグ（空ならグラフなし）
+   */
+  const [selectedLineTagKeys, setSelectedLineTagKeys] = useState<string[] | 'default'>('default')
+
+  const resolvedLineTags = useMemo(() => {
+    if (availableTagsForLine.length === 0) return []
+    if (selectedLineTagKeys === 'default') {
+      return tagsForDefaultLineChart.slice(0, Math.min(DEFAULT_LINE_TAG_COUNT, tagsForDefaultLineChart.length))
+    }
+    return selectedLineTagKeys.filter((t) => availableTagsForLine.includes(t))
+  }, [availableTagsForLine, selectedLineTagKeys, tagsForDefaultLineChart])
+
+  useEffect(() => {
+    setSelectedLineTagKeys((prev) => {
+      if (prev === 'default') return prev
+      const next = prev.filter((t) => availableTagsForLine.includes(t))
+      if (next.length === 0 && availableTagsForLine.length > 0) return 'default'
+      return next
+    })
+  }, [availableTagsForLine])
+
+  const toggleLineTag = useCallback(
+    (tag: string) => {
+      setSelectedLineTagKeys((prev) => {
+        const base =
+          prev === 'default'
+            ? tagsForDefaultLineChart.slice(0, Math.min(DEFAULT_LINE_TAG_COUNT, tagsForDefaultLineChart.length))
+            : [...prev]
+        const isOn = base.includes(tag)
+        const next = isOn ? base.filter((t) => t !== tag) : [...base, tag]
+        return next.sort(
+          (a, b) => availableTagsForLine.indexOf(a) - availableTagsForLine.indexOf(b)
+        )
+      })
+    },
+    [availableTagsForLine, tagsForDefaultLineChart]
+  )
+
+  const resetLineTagsToDefaultTop = useCallback(() => {
+    setSelectedLineTagKeys('default')
+  }, [])
+
+  /** チェックボックス一覧の絞り込み（タグ数が多いとき用） */
+  const [lineTagFilterQuery, setLineTagFilterQuery] = useState('')
+
+  const filteredTagsForPicker = useMemo(() => {
+    const q = lineTagFilterQuery.trim()
+    if (!q) return availableTagsForLine
+    return availableTagsForLine.filter((t) => t.includes(q))
+  }, [availableTagsForLine, lineTagFilterQuery])
+
+  const lineChartTagRows = useMemo(() => {
+    const sorted = [...monthlyData].sort((a, b) => {
+      if (a.year !== b.year) return a.year - b.year
+      return a.month - b.month
+    })
+    return sorted.map((m) => {
+      const row: Record<string, string | number> = {
+        month: `${m.year}/${String(m.month).padStart(2, '0')}`,
+        year: m.year,
+        monthNum: m.month,
+      }
+      resolvedLineTags.forEach((tag) => {
+        row[tag] = m.tagBreakdown[tag] ?? 0
+      })
+      return row
+    })
+  }, [monthlyData, resolvedLineTags])
+
   // 選択された月の詳細データ
   const [selectedMonth, setSelectedMonth] = useState<string | null>(null)
 
@@ -100,6 +230,41 @@ const MonthlySummary = () => {
       console.error('Sign out failed', error)
     }
   }
+
+  /** 支出検索（詳細）へ。タグ経由のときはマスタのカテゴリーも付与 */
+  const goToExpenseDetail = (
+    year: number,
+    month: number,
+    filter?: { category?: string; tag?: string }
+  ) => {
+    const q = new URLSearchParams({ year: String(year), month: String(month) })
+    let categoryName = filter?.category
+    if (filter?.tag && filter.tag !== TAG_NONE_LABEL && !categoryName) {
+      categoryName = categoryNameByTagName.get(filter.tag)
+    }
+    if (categoryName) q.set('category', categoryName)
+    if (filter?.tag) q.set('tag', filter.tag)
+    navigate(`/monthly-expenses?${q.toString()}`)
+  }
+
+  const ChartGroupToggle = () => (
+    <div className="chart-group-toggle" role="group" aria-label="グラフの分類">
+      <button
+        type="button"
+        className={chartGroupBy === 'category' ? 'chart-group-toggle-btn active' : 'chart-group-toggle-btn'}
+        onClick={() => setChartGroupBy('category')}
+      >
+        カテゴリー
+      </button>
+      <button
+        type="button"
+        className={chartGroupBy === 'tag' ? 'chart-group-toggle-btn active' : 'chart-group-toggle-btn'}
+        onClick={() => setChartGroupBy('tag')}
+      >
+        タグ
+      </button>
+    </div>
+  )
 
   const formatMonth = (year: number, month: number) => {
     return `${year}年${month}月`
@@ -226,7 +391,10 @@ const MonthlySummary = () => {
 
         {/* 月毎の一覧 */}
         <section className="monthly-summary-card monthly-list-section">
-          <h2>月毎の支出</h2>
+          <div className="monthly-section-heading">
+            <h2>月毎の支出</h2>
+            <ChartGroupToggle />
+          </div>
           {loadingExpenses ? (
             <p className="loading-text">読み込み中...</p>
           ) : monthlyData.length === 0 ? (
@@ -257,42 +425,69 @@ const MonthlySummary = () => {
                     {isExpanded && (
                       <div className="monthly-item-details">
                         <div className="category-breakdown">
-                          <h4>カテゴリー別内訳</h4>
-                          {Object.keys(data.categoryBreakdown).length === 0 ? (
-                            <p className="empty-message">カテゴリー別のデータがありません</p>
-                          ) : (
-                            <div className="chart-container">
-                              <div className="chart-wrapper">
-                                <ResponsiveContainer width="100%" height={350}>
-                                  <PieChart margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
-                                    <Pie
-                                      data={prepareChartData(data.categoryBreakdown, data.total)}
-                                      cx="50%"
-                                      cy="50%"
-                                      labelLine={false}
-                                      outerRadius={90}
-                                      fill="#8884d8"
-                                      dataKey="value"
-                                    >
-                                      {prepareChartData(data.categoryBreakdown, data.total).map(
-                                        (_entry, index) => (
+                          <h4>
+                            {chartGroupBy === 'category' ? 'カテゴリー別内訳' : 'タグ別内訳'}
+                          </h4>
+                          {(() => {
+                            const breakdown =
+                              chartGroupBy === 'category'
+                                ? data.categoryBreakdown
+                                : data.tagBreakdown
+                            const chartRows = prepareChartData(breakdown, data.total)
+                            return Object.keys(breakdown).length === 0 || chartRows.length === 0 ? (
+                              <p className="empty-message">
+                                {chartGroupBy === 'category'
+                                  ? 'カテゴリー別のデータがありません'
+                                  : 'タグ別のデータがありません'}
+                              </p>
+                            ) : (
+                              <div className="chart-container">
+                                <div className="chart-wrapper">
+                                  <ResponsiveContainer width="100%" height={350}>
+                                    <PieChart margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
+                                      <Pie
+                                        data={chartRows}
+                                        cx="50%"
+                                        cy="50%"
+                                        labelLine={false}
+                                        outerRadius={90}
+                                        fill="#8884d8"
+                                        dataKey="value"
+                                        style={{ cursor: 'pointer' }}
+                                        onClick={(slice) => {
+                                          const name =
+                                            slice &&
+                                            typeof slice === 'object' &&
+                                            'name' in slice &&
+                                            typeof (slice as { name?: unknown }).name === 'string'
+                                              ? (slice as { name: string }).name
+                                              : null
+                                          if (!name) return
+                                          if (chartGroupBy === 'category') {
+                                            goToExpenseDetail(data.year, data.month, {
+                                              category: name,
+                                            })
+                                          } else {
+                                            goToExpenseDetail(data.year, data.month, { tag: name })
+                                          }
+                                        }}
+                                      >
+                                        {chartRows.map((_entry, index) => (
                                           <Cell
                                             key={`cell-${index}`}
                                             fill={COLORS[index % COLORS.length]}
                                           />
-                                        )
-                                      )}
-                                    </Pie>
-                                    <Tooltip
-                                      content={<CustomTooltip />}
-                                      cursor={{ fill: 'transparent' }}
-                                    />
-                                  </PieChart>
-                                </ResponsiveContainer>
-                              </div>
-                              <div className="chart-legend">
-                                {prepareChartData(data.categoryBreakdown, data.total).map(
-                                  (entry, index) => (
+                                        ))}
+                                      </Pie>
+                                      <Tooltip
+                                        content={<CustomTooltip />}
+                                        cursor={{ fill: 'transparent' }}
+                                      />
+                                    </PieChart>
+                                  </ResponsiveContainer>
+                                </div>
+                                <div className="chart-legend">
+                                  {chartRows.map((entry, index) => (
                                     <div key={index} className="legend-item">
                                       <span
                                         className="legend-color"
@@ -303,11 +498,11 @@ const MonthlySummary = () => {
                                         ¥{entry.value.toLocaleString()} ({entry.percentage}%)
                                       </span>
                                     </div>
-                                  )
-                                )}
+                                  ))}
+                                </div>
                               </div>
-                            </div>
-                          )}
+                            )
+                          })()}
                         </div>
                         <div className="monthly-item-actions">
                           <Link
@@ -327,56 +522,280 @@ const MonthlySummary = () => {
         </section>
 
         {/* 月別支出推移グラフ */}
-        {!loadingExpenses && lineChartData.length > 0 && (
+        {!loadingExpenses && monthlyData.length > 0 && (
           <section className="monthly-summary-card line-chart-section">
-            <h2>月別支出推移</h2>
-            <div className="line-chart-container">
-              <ResponsiveContainer width="100%" height={300}>
-                <LineChart data={lineChartData} margin={{ top: 5, right: 20, bottom: 60, left: 20 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
-                  <XAxis
-                    dataKey="month"
-                    stroke="#64748b"
-                    style={{ fontSize: '0.75rem' }}
-                    angle={-45}
-                    textAnchor="end"
-                    height={80}
-                  />
-                  <YAxis
-                    stroke="#64748b"
-                    style={{ fontSize: '0.75rem' }}
-                    tickFormatter={(value: number) => {
-                      if (value >= 10000) {
-                        return `¥${(value / 10000).toFixed(0)}万`
-                      }
-                      return `¥${value.toLocaleString()}`
-                    }}
-                    width={60}
-                  />
-                  <Tooltip
-                    contentStyle={{
-                      backgroundColor: '#fff',
-                      border: '1px solid #e2e8f0',
-                      borderRadius: '0.5rem',
-                      color: '#0f172a',
-                    }}
-                    formatter={(value: number | undefined) => {
-                      if (value === undefined) return ['', '支出']
-                      return [`¥${value.toLocaleString()}`, '支出']
-                    }}
-                    labelStyle={{ color: '#0f172a', fontWeight: 600 }}
-                  />
-                  <Line
-                    type="monotone"
-                    dataKey="amount"
-                    stroke="#667eea"
-                    strokeWidth={2}
-                    dot={{ fill: '#667eea', r: 4 }}
-                    activeDot={{ r: 6 }}
-                  />
-                </LineChart>
-              </ResponsiveContainer>
+            <div className="monthly-section-heading">
+              <h2>
+                {chartGroupBy === 'category' ? '月別支出推移' : '月別支出推移（タグ別）'}
+              </h2>
+              <ChartGroupToggle />
             </div>
+            <div
+              className={
+                chartGroupBy === 'tag' ? 'line-chart-container line-chart-container--with-legend' : 'line-chart-container'
+              }
+            >
+              {chartGroupBy === 'category' && lineChartData.length === 0 ? (
+                <p className="empty-message">表示できるデータがありません</p>
+              ) : chartGroupBy === 'tag' && availableTagsForLine.length === 0 ? (
+                <p className="empty-message">タグ別の推移を表示するデータがありません</p>
+              ) : chartGroupBy === 'tag' && resolvedLineTags.length === 0 ? (
+                <p className="empty-message">表示するタグを1件以上選んでください</p>
+              ) : (
+                <ResponsiveContainer width="100%" height="100%">
+                  {chartGroupBy === 'category' ? (
+                    <LineChart data={lineChartData} margin={{ top: 5, right: 20, bottom: 60, left: 20 }}>
+                      <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+                      <XAxis
+                        dataKey="month"
+                        stroke="#64748b"
+                        style={{ fontSize: '0.75rem' }}
+                        angle={-45}
+                        textAnchor="end"
+                        height={80}
+                      />
+                      <YAxis
+                        stroke="#64748b"
+                        style={{ fontSize: '0.75rem' }}
+                        tickFormatter={(value: number) => {
+                          if (value >= 10000) {
+                            return `¥${(value / 10000).toFixed(0)}万`
+                          }
+                          return `¥${value.toLocaleString()}`
+                        }}
+                        width={60}
+                      />
+                      <Tooltip
+                        contentStyle={{
+                          backgroundColor: '#fff',
+                          border: '1px solid #e2e8f0',
+                          borderRadius: '0.5rem',
+                          color: '#0f172a',
+                        }}
+                        formatter={(value: number | undefined) => {
+                          if (value === undefined) return ['', '支出']
+                          return [`¥${value.toLocaleString()}`, '支出']
+                        }}
+                        labelStyle={{ color: '#0f172a', fontWeight: 600 }}
+                      />
+                      <Line
+                        type="monotone"
+                        dataKey="amount"
+                        stroke="#667eea"
+                        strokeWidth={2}
+                        name="合計"
+                        dot={(props: {
+                          cx?: number
+                          cy?: number
+                          payload?: { year: number; monthNum: number }
+                        }) => {
+                          const { cx, cy, payload } = props
+                          if (cx == null || cy == null || !payload) return null
+                          return (
+                            <circle
+                              cx={cx}
+                              cy={cy}
+                              r={4}
+                              fill="#667eea"
+                              style={{ cursor: 'pointer' }}
+                              aria-label={`${payload.year}年${payload.monthNum}月の詳細を開く`}
+                              onClick={(e) => {
+                                e.stopPropagation()
+                                goToExpenseDetail(payload.year, payload.monthNum)
+                              }}
+                            />
+                          )
+                        }}
+                        activeDot={(props: {
+                          cx?: number
+                          cy?: number
+                          payload?: { year: number; monthNum: number }
+                        }) => {
+                          const { cx, cy, payload } = props
+                          if (cx == null || cy == null || !payload) return null
+                          return (
+                            <circle
+                              cx={cx}
+                              cy={cy}
+                              r={6}
+                              fill="#667eea"
+                              style={{ cursor: 'pointer' }}
+                              aria-label={`${payload.year}年${payload.monthNum}月の詳細を開く`}
+                              onClick={(e) => {
+                                e.stopPropagation()
+                                goToExpenseDetail(payload.year, payload.monthNum)
+                              }}
+                            />
+                          )
+                        }}
+                      />
+                    </LineChart>
+                  ) : (
+                    <LineChart data={lineChartTagRows} margin={{ top: 5, right: 20, bottom: 60, left: 20 }}>
+                      <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+                      <XAxis
+                        dataKey="month"
+                        stroke="#64748b"
+                        style={{ fontSize: '0.75rem' }}
+                        angle={-45}
+                        textAnchor="end"
+                        height={80}
+                      />
+                      <YAxis
+                        stroke="#64748b"
+                        style={{ fontSize: '0.75rem' }}
+                        tickFormatter={(value: number) => {
+                          if (value >= 10000) {
+                            return `¥${(value / 10000).toFixed(0)}万`
+                          }
+                          return `¥${value.toLocaleString()}`
+                        }}
+                        width={60}
+                      />
+                      <Tooltip
+                        contentStyle={{
+                          backgroundColor: '#fff',
+                          border: '1px solid #e2e8f0',
+                          borderRadius: '0.5rem',
+                          color: '#0f172a',
+                        }}
+                        formatter={(value: number | undefined, name: string | undefined) => {
+                          if (value === undefined) return ['', name ?? '']
+                          return [`¥${value.toLocaleString()}`, name ?? '']
+                        }}
+                        labelStyle={{ color: '#0f172a', fontWeight: 600 }}
+                      />
+                      <Legend wrapperStyle={{ paddingTop: '0.5rem', fontSize: '0.75rem', color: '#334155' }} />
+                      {resolvedLineTags.map((tagName, tagIndex) => (
+                        <Line
+                          key={tagName}
+                          type="monotone"
+                          dataKey={tagName}
+                          stroke={COLORS[tagIndex % COLORS.length]}
+                          strokeWidth={2}
+                          dot={(props: {
+                            cx?: number
+                            cy?: number
+                            payload?: Record<string, string | number>
+                          }) => {
+                            const { cx, cy, payload } = props
+                            if (cx == null || cy == null || !payload) return null
+                            const year = payload.year as number
+                            const monthNum = payload.monthNum as number
+                            return (
+                              <circle
+                                cx={cx}
+                                cy={cy}
+                                r={4}
+                                fill={COLORS[tagIndex % COLORS.length]}
+                                style={{ cursor: 'pointer' }}
+                                aria-label={`${year}年${monthNum}月・${tagName}の詳細を開く`}
+                                onClick={(e) => {
+                                  e.stopPropagation()
+                                  goToExpenseDetail(year, monthNum, { tag: tagName })
+                                }}
+                              />
+                            )
+                          }}
+                          activeDot={(props: {
+                            cx?: number
+                            cy?: number
+                            payload?: Record<string, string | number>
+                          }) => {
+                            const { cx, cy, payload } = props
+                            if (cx == null || cy == null || !payload) return null
+                            const year = payload.year as number
+                            const monthNum = payload.monthNum as number
+                            return (
+                              <circle
+                                cx={cx}
+                                cy={cy}
+                                r={6}
+                                fill={COLORS[tagIndex % COLORS.length]}
+                                style={{ cursor: 'pointer' }}
+                                aria-label={`${year}年${monthNum}月・${tagName}の詳細を開く`}
+                                onClick={(e) => {
+                                  e.stopPropagation()
+                                  goToExpenseDetail(year, monthNum, { tag: tagName })
+                                }}
+                              />
+                            )
+                          }}
+                        />
+                      ))}
+                    </LineChart>
+                  )}
+                </ResponsiveContainer>
+              )}
+            </div>
+            {chartGroupBy === 'tag' && availableTagsForLine.length > 0 && (
+              <div className="line-chart-tag-picker">
+                <fieldset className="line-chart-tag-picker-fieldset">
+                  <legend className="line-chart-tag-picker-legend">表示するタグ</legend>
+                  <p className="line-chart-tag-picker-hint">
+                    {selectedLineTagKeys === 'default'
+                      ? `既定は金額合計の大きいタグから${DEFAULT_LINE_TAG_COUNT}件です（「${TAG_NONE_LABEL}」は除きます）。チェックで追加・解除できます。`
+                      : 'チェックを外すとその系列が非表示になります。'}
+                  </p>
+                  <div className="line-chart-tag-picker-toolbar">
+                    <label className="line-chart-tag-filter-wrap" htmlFor="line-tag-filter-input">
+                      <span className="line-chart-tag-filter-sr-label">タグ名で絞り込み</span>
+                      <input
+                        id="line-tag-filter-input"
+                        type="search"
+                        className="line-chart-tag-filter-input"
+                        placeholder="タグ名で絞り込み…"
+                        value={lineTagFilterQuery}
+                        onChange={(e) => setLineTagFilterQuery(e.target.value)}
+                        autoComplete="off"
+                        enterKeyHint="search"
+                      />
+                    </label>
+                    {lineTagFilterQuery.trim() !== '' && (
+                      <button
+                        type="button"
+                        className="line-chart-tag-filter-clear"
+                        onClick={() => setLineTagFilterQuery('')}
+                      >
+                        絞り込みをクリア
+                      </button>
+                    )}
+                    <button
+                      type="button"
+                      className="line-chart-tag-picker-reset"
+                      onClick={resetLineTagsToDefaultTop}
+                    >
+                      上位{DEFAULT_LINE_TAG_COUNT}件に戻す
+                    </button>
+                  </div>
+                  <p className="line-chart-tag-picker-count" aria-live="polite">
+                    {lineTagFilterQuery.trim() !== ''
+                      ? `表示中 ${filteredTagsForPicker.length}件 / 全${availableTagsForLine.length}件`
+                      : `全${availableTagsForLine.length}件`}
+                  </p>
+                  <div className="line-chart-tag-checkboxes-scroll">
+                    {filteredTagsForPicker.length === 0 ? (
+                      <p className="line-chart-tag-filter-empty">一致するタグがありません</p>
+                    ) : (
+                      <div className="line-chart-tag-checkboxes" role="group" aria-label="表示するタグの選択">
+                        {filteredTagsForPicker.map((tag) => (
+                          <label key={tag} className="line-chart-tag-checkbox-label">
+                            <input
+                              type="checkbox"
+                              checked={resolvedLineTags.includes(tag)}
+                              onChange={() => toggleLineTag(tag)}
+                            />
+                            <span className="line-chart-tag-checkbox-text" title={tag}>
+                              {tag}
+                            </span>
+                          </label>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </fieldset>
+              </div>
+            )}
           </section>
         )}
       </main>

--- a/src/services/expenseService.ts
+++ b/src/services/expenseService.ts
@@ -2,32 +2,106 @@ import {
   collection,
   query,
   where,
+  orderBy,
+  limit,
+  startAfter,
   getDocs,
-  addDoc,
-  updateDoc,
-  deleteDoc,
+  getDoc,
   doc,
+  writeBatch,
   Timestamp,
+  increment,
+  setDoc,
+  type DocumentData,
+  type QueryDocumentSnapshot,
 } from 'firebase/firestore'
 import { db } from '../firebase/config'
 import type { Expense, CreateExpenseInput, UpdateExpenseInput } from '../types'
 
+const COLLECTION = 'expenses'
+
+export type ExpensePageResult = {
+  expenses: Expense[]
+  lastDoc: QueryDocumentSnapshot<DocumentData> | null
+  hasMore: boolean
+}
+
+function monthlyTotalPeriodId(year: number, month: number): string {
+  return `${year}_${String(month).padStart(2, '0')}`
+}
+
+function monthlyTotalDocRef(userId: string, year: number, month: number) {
+  return doc(db, 'users', userId, 'monthlyTotals', monthlyTotalPeriodId(year, month))
+}
+
+function docToExpense(id: string, d: DocumentData): Expense {
+  return { id, ...d } as Expense
+}
+
+function sameCalendarMonth(a: Date, b: Date): boolean {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth()
+}
+
+function applyMonthlyDeltaInBatch(
+  batch: ReturnType<typeof writeBatch>,
+  userId: string,
+  expenseDate: Date,
+  delta: number
+): void {
+  const y = expenseDate.getFullYear()
+  const m = expenseDate.getMonth() + 1
+  const ref = monthlyTotalDocRef(userId, y, m)
+  batch.set(
+    ref,
+    {
+      userId,
+      year: y,
+      month: m,
+      total: increment(delta),
+      updatedAt: Timestamp.now(),
+    },
+    { merge: true }
+  )
+}
+
+function monthDateRangeTimestamps(year: number, month: number): { start: Timestamp; end: Timestamp } {
+  const start = new Date(year, month - 1, 1)
+  const end = new Date(year, month, 0, 23, 59, 59, 999)
+  return { start: Timestamp.fromDate(start), end: Timestamp.fromDate(end) }
+}
+
+async function sumExpensesInMonth(
+  userId: string,
+  year: number,
+  month: number
+): Promise<number> {
+  const { start, end } = monthDateRangeTimestamps(year, month)
+  const q = query(
+    collection(db, COLLECTION),
+    where('userId', '==', userId),
+    where('date', '>=', start),
+    where('date', '<=', end)
+  )
+  const snap = await getDocs(q)
+  let sum = 0
+  snap.forEach((d) => {
+    sum += (d.data().amount as number) || 0
+  })
+  return sum
+}
+
 export const expenseService = {
-  // ユーザーIDで支出一覧を取得
+  /** 一覧画面・月次ページ用（全件取得。読取は件数分） */
   async getExpensesByUserId(userId: string): Promise<Expense[]> {
-    const expensesRef = collection(db, 'expenses')
+    const expensesRef = collection(db, COLLECTION)
     const q = query(expensesRef, where('userId', '==', userId))
     const querySnapshot = await getDocs(q)
 
     const expenses: Expense[] = []
-    querySnapshot.forEach((doc) => {
-      expenses.push({
-        id: doc.id,
-        ...doc.data(),
-      } as Expense)
+    querySnapshot.forEach((d) => {
+      expenses.push(docToExpense(d.id, d.data()))
     })
 
-    // 日付でソート（新しい順）
     expenses.sort((a, b) => {
       const dateA = a.date?.toMillis() || 0
       const dateB = b.date?.toMillis() || 0
@@ -37,56 +111,199 @@ export const expenseService = {
     return expenses
   },
 
-  // 支出を作成
+  /**
+   * 指定月の支出のみ取得（orderBy なし・既存の月範囲インデックス向け）。クライアントで日付降順に整列。
+   */
+  async getExpensesInMonth(userId: string, year: number, month: number): Promise<Expense[]> {
+    const { start, end } = monthDateRangeTimestamps(year, month)
+    const q = query(
+      collection(db, COLLECTION),
+      where('userId', '==', userId),
+      where('date', '>=', start),
+      where('date', '<=', end)
+    )
+    const snap = await getDocs(q)
+    const list: Expense[] = []
+    snap.forEach((d) => {
+      list.push(docToExpense(d.id, d.data()))
+    })
+    list.sort((a, b) => (b.date?.toMillis() || 0) - (a.date?.toMillis() || 0))
+    return list
+  },
+
+  /**
+   * 複合インデックスなしでも動くフォールバック用（userId のみで取得し、指定月にクライアント側で絞り込み）
+   */
+  filterExpensesInCalendarMonth(expenses: Expense[], year: number, month: number): Expense[] {
+    return expenses
+      .filter((e) => {
+        if (!e.date) return false
+        const d = e.date.toDate()
+        return d.getFullYear() === year && d.getMonth() + 1 === month
+      })
+      .sort((a, b) => (b.date?.toMillis() || 0) - (a.date?.toMillis() || 0))
+  },
+
+  /**
+   * 指定月のみサーバー側ページング（最大 pageSize+1 件読取）
+   */
+  async getExpensesPageForMonth(
+    userId: string,
+    year: number,
+    month: number,
+    pageSize: number,
+    startAfterDoc?: QueryDocumentSnapshot<DocumentData>
+  ): Promise<ExpensePageResult> {
+    const { start, end } = monthDateRangeTimestamps(year, month)
+    const expensesRef = collection(db, COLLECTION)
+    const base = [
+      where('userId', '==', userId),
+      where('date', '>=', start),
+      where('date', '<=', end),
+      orderBy('date', 'desc'),
+      limit(pageSize + 1),
+    ] as const
+    const q = startAfterDoc
+      ? query(expensesRef, ...base, startAfter(startAfterDoc))
+      : query(expensesRef, ...base)
+
+    const snap = await getDocs(q)
+    const docs = snap.docs
+    const hasMore = docs.length > pageSize
+    const slice = hasMore ? docs.slice(0, pageSize) : docs
+
+    const expenses = slice.map((d) => docToExpense(d.id, d.data()))
+    const lastDoc = slice.length > 0 ? slice[slice.length - 1] : null
+
+    return { expenses, lastDoc, hasMore }
+  },
+
+  /**
+   * 全期間サーバー側ページング（最大 pageSize+1 件読取）
+   */
+  async getExpensesPage(
+    userId: string,
+    pageSize: number,
+    startAfterDoc?: QueryDocumentSnapshot<DocumentData>
+  ): Promise<ExpensePageResult> {
+    const expensesRef = collection(db, COLLECTION)
+    const base = [
+      where('userId', '==', userId),
+      orderBy('date', 'desc'),
+      limit(pageSize + 1),
+    ] as const
+    const q = startAfterDoc
+      ? query(expensesRef, ...base, startAfter(startAfterDoc))
+      : query(expensesRef, ...base)
+
+    const snap = await getDocs(q)
+    const docs = snap.docs
+    const hasMore = docs.length > pageSize
+    const slice = hasMore ? docs.slice(0, pageSize) : docs
+
+    const expenses = slice.map((d) => docToExpense(d.id, d.data()))
+    const lastDoc = slice.length > 0 ? slice[slice.length - 1] : null
+
+    return { expenses, lastDoc, hasMore }
+  },
+
+  /**
+   * ダッシュボード「今月の合計」用。集計ドキュメントが無ければ当月分だけ集計してキャッシュ。
+   */
+  async getMonthlyTotalForDisplay(userId: string, year: number, month: number): Promise<number> {
+    const ref = monthlyTotalDocRef(userId, year, month)
+    const snap = await getDoc(ref)
+    if (snap.exists()) {
+      return Number(snap.data()?.total ?? 0)
+    }
+    const total = await sumExpensesInMonth(userId, year, month)
+    await setDoc(ref, {
+      userId,
+      year,
+      month,
+      total,
+      updatedAt: Timestamp.now(),
+    })
+    return total
+  },
+
   async createExpense(userId: string, input: CreateExpenseInput): Promise<string> {
     const now = Timestamp.now()
     const expenseDate = Timestamp.fromDate(input.date)
     const tagsString = input.tags.join(', ')
 
-    const docRef = await addDoc(collection(db, 'expenses'), {
+    const batch = writeBatch(db)
+    const expenseRef = doc(collection(db, COLLECTION))
+    batch.set(expenseRef, {
       userId,
       date: expenseDate,
       amount: input.amount,
       bigCategory: input.bigCategory,
       tags: tagsString,
-      paymentMethod: input.paymentMethod,
+      paymentMethod: input.paymentMethod ?? '',
       description: input.description || '',
       createdAt: now,
       updatedAt: now,
     })
-
-    return docRef.id
+    applyMonthlyDeltaInBatch(batch, userId, input.date, input.amount)
+    await batch.commit()
+    return expenseRef.id
   },
 
-  // 支出を更新
   async updateExpense(expenseId: string, input: UpdateExpenseInput): Promise<void> {
-    const expenseRef = doc(db, 'expenses', expenseId)
-    const updateData: {
-      updatedAt: Timestamp
-      date?: Timestamp
-      amount?: number
-      bigCategory?: string
-      tags?: string
-      paymentMethod?: string
-      description?: string
-    } = {
+    const expenseRef = doc(db, COLLECTION, expenseId)
+    const oldSnap = await getDoc(expenseRef)
+    if (!oldSnap.exists()) {
+      throw new Error('Expense not found')
+    }
+    const old = oldSnap.data()
+    const oldUserId = old.userId as string
+    const oldDate = (old.date as Timestamp).toDate()
+    const oldAmount = (old.amount as number) || 0
+
+    const newDate = input.date ?? oldDate
+    const newAmount = input.amount !== undefined ? input.amount : oldAmount
+
+    const updateData: Record<string, unknown> = {
       updatedAt: Timestamp.now(),
     }
-
     if (input.date) updateData.date = Timestamp.fromDate(input.date)
     if (input.amount !== undefined) updateData.amount = input.amount
     if (input.bigCategory) updateData.bigCategory = input.bigCategory
     if (input.tags) updateData.tags = input.tags.join(', ')
-    if (input.paymentMethod) updateData.paymentMethod = input.paymentMethod
+    if (input.paymentMethod !== undefined) updateData.paymentMethod = input.paymentMethod
     if (input.description !== undefined) updateData.description = input.description
 
-    await updateDoc(expenseRef, updateData)
+    const batch = writeBatch(db)
+    batch.update(expenseRef, updateData as Record<string, never>)
+
+    if (sameCalendarMonth(oldDate, newDate)) {
+      const delta = newAmount - oldAmount
+      if (delta !== 0) {
+        applyMonthlyDeltaInBatch(batch, oldUserId, oldDate, delta)
+      }
+    } else {
+      applyMonthlyDeltaInBatch(batch, oldUserId, oldDate, -oldAmount)
+      applyMonthlyDeltaInBatch(batch, oldUserId, newDate, newAmount)
+    }
+
+    await batch.commit()
   },
 
-  // 支出を削除
   async deleteExpense(expenseId: string): Promise<void> {
-    const expenseRef = doc(db, 'expenses', expenseId)
-    await deleteDoc(expenseRef)
+    const expenseRef = doc(db, COLLECTION, expenseId)
+    const oldSnap = await getDoc(expenseRef)
+    if (!oldSnap.exists()) {
+      throw new Error('Expense not found')
+    }
+    const old = oldSnap.data()
+    const userId = old.userId as string
+    const expenseDate = (old.date as Timestamp).toDate()
+    const amount = (old.amount as number) || 0
+
+    const batch = writeBatch(db)
+    batch.delete(expenseRef)
+    applyMonthlyDeltaInBatch(batch, userId, expenseDate, -amount)
+    await batch.commit()
   },
 }
-

--- a/src/services/expenseService.ts
+++ b/src/services/expenseService.ts
@@ -80,7 +80,8 @@ async function sumExpensesInMonth(
     collection(db, COLLECTION),
     where('userId', '==', userId),
     where('date', '>=', start),
-    where('date', '<=', end)
+    where('date', '<=', end),
+    orderBy('date', 'desc')
   )
   const snap = await getDocs(q)
   let sum = 0
@@ -112,7 +113,7 @@ export const expenseService = {
   },
 
   /**
-   * 指定月の支出のみ取得（orderBy なし・既存の月範囲インデックス向け）。クライアントで日付降順に整列。
+   * 指定月の支出のみ取得。範囲フィルタと同じフィールドで orderBy が必要なため date 降順（複合インデックス: userId + date）。
    */
   async getExpensesInMonth(userId: string, year: number, month: number): Promise<Expense[]> {
     const { start, end } = monthDateRangeTimestamps(year, month)
@@ -120,14 +121,14 @@ export const expenseService = {
       collection(db, COLLECTION),
       where('userId', '==', userId),
       where('date', '>=', start),
-      where('date', '<=', end)
+      where('date', '<=', end),
+      orderBy('date', 'desc')
     )
     const snap = await getDocs(q)
     const list: Expense[] = []
     snap.forEach((d) => {
       list.push(docToExpense(d.id, d.data()))
     })
-    list.sort((a, b) => (b.date?.toMillis() || 0) - (a.date?.toMillis() || 0))
     return list
   },
 

--- a/src/services/expenseService.ts
+++ b/src/services/expenseService.ts
@@ -70,20 +70,24 @@ function monthDateRangeTimestamps(year: number, month: number): { start: Timesta
   return { start: Timestamp.fromDate(start), end: Timestamp.fromDate(end) }
 }
 
-async function sumExpensesInMonth(
-  userId: string,
-  year: number,
-  month: number
-): Promise<number> {
+/** 指定暦月の支出クエリ（userId + date 範囲 + date 降順）。getExpensesInMonth / 月次合計集計で共有 */
+function expensesInMonthOrderedQuery(userId: string, year: number, month: number) {
   const { start, end } = monthDateRangeTimestamps(year, month)
-  const q = query(
+  return query(
     collection(db, COLLECTION),
     where('userId', '==', userId),
     where('date', '>=', start),
     where('date', '<=', end),
     orderBy('date', 'desc')
   )
-  const snap = await getDocs(q)
+}
+
+async function sumExpensesInMonth(
+  userId: string,
+  year: number,
+  month: number
+): Promise<number> {
+  const snap = await getDocs(expensesInMonthOrderedQuery(userId, year, month))
   let sum = 0
   snap.forEach((d) => {
     sum += (d.data().amount as number) || 0
@@ -116,33 +120,12 @@ export const expenseService = {
    * 指定月の支出のみ取得。範囲フィルタと同じフィールドで orderBy が必要なため date 降順（複合インデックス: userId + date）。
    */
   async getExpensesInMonth(userId: string, year: number, month: number): Promise<Expense[]> {
-    const { start, end } = monthDateRangeTimestamps(year, month)
-    const q = query(
-      collection(db, COLLECTION),
-      where('userId', '==', userId),
-      where('date', '>=', start),
-      where('date', '<=', end),
-      orderBy('date', 'desc')
-    )
-    const snap = await getDocs(q)
+    const snap = await getDocs(expensesInMonthOrderedQuery(userId, year, month))
     const list: Expense[] = []
     snap.forEach((d) => {
       list.push(docToExpense(d.id, d.data()))
     })
     return list
-  },
-
-  /**
-   * 複合インデックスなしでも動くフォールバック用（userId のみで取得し、指定月にクライアント側で絞り込み）
-   */
-  filterExpensesInCalendarMonth(expenses: Expense[], year: number, month: number): Expense[] {
-    return expenses
-      .filter((e) => {
-        if (!e.date) return false
-        const d = e.date.toDate()
-        return d.getFullYear() === year && d.getMonth() + 1 === month
-      })
-      .sort((a, b) => (b.date?.toMillis() || 0) - (a.date?.toMillis() || 0))
   },
 
   /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,7 +20,7 @@ export interface CreateExpenseInput {
   amount: number
   bigCategory: string
   tags: string[]
-  paymentMethod: string
+  paymentMethod?: string
   description?: string
 }
 

--- a/src/utils/dashboardYearMonth.test.ts
+++ b/src/utils/dashboardYearMonth.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { isSameYearMonth, buildDashboardYearOptions } from './dashboardYearMonth'
+
+describe('isSameYearMonth', () => {
+  it('returns true when year and month match', () => {
+    expect(isSameYearMonth({ year: 2026, month: 4 }, { year: 2026, month: 4 })).toBe(true)
+  })
+
+  it('returns false when year or month differs', () => {
+    expect(isSameYearMonth({ year: 2026, month: 4 }, { year: 2026, month: 5 })).toBe(false)
+    expect(isSameYearMonth({ year: 2026, month: 4 }, { year: 2025, month: 4 })).toBe(false)
+  })
+})
+
+describe('buildDashboardYearOptions', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('includes selected year and spans default window around current year', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-01T12:00:00Z'))
+
+    const opts = buildDashboardYearOptions(2026)
+    expect(opts[0]).toBe(2016)
+    expect(opts[opts.length - 1]).toBe(2027)
+    expect(opts).toContain(2026)
+  })
+
+  it('extends range when selected year is far in the past', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-01T12:00:00Z'))
+
+    const opts = buildDashboardYearOptions(2010)
+    expect(opts).toContain(2010)
+    expect(opts[0]).toBeLessThanOrEqual(2010)
+  })
+})

--- a/src/utils/dashboardYearMonth.ts
+++ b/src/utils/dashboardYearMonth.ts
@@ -1,0 +1,16 @@
+/** ダッシュボードの年月プルダウン用（{ year, month } の比較・年リスト生成） */
+
+export function isSameYearMonth(
+  a: { year: number; month: number },
+  b: { year: number; month: number }
+): boolean {
+  return a.year === b.year && a.month === b.month
+}
+
+/** 選択年を含む、今年±の年一覧（プルダウン用） */
+export function buildDashboardYearOptions(selectedYear: number): number[] {
+  const cy = new Date().getFullYear()
+  const from = Math.min(selectedYear, cy - 10)
+  const to = Math.max(selectedYear, cy + 1)
+  return Array.from({ length: to - from + 1 }, (_, i) => from + i)
+}

--- a/src/utils/pagination.test.ts
+++ b/src/utils/pagination.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { buildPaginationItems } from './pagination'
+
+describe('buildPaginationItems', () => {
+  it('returns single page for total 1', () => {
+    expect(buildPaginationItems(1, 1)).toEqual([1])
+  })
+
+  it('returns all pages when total is small', () => {
+    expect(buildPaginationItems(3, 5)).toEqual([1, 2, 3, 4, 5])
+  })
+
+  it('includes ellipsis for large total', () => {
+    const items = buildPaginationItems(5, 20)
+    expect(items).toContain(1)
+    expect(items).toContain(20)
+    expect(items).toContain(5)
+    expect(items).toContain('ellipsis')
+  })
+})

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -1,0 +1,29 @@
+/** ページ番号ボタン用。連続しない区間は 'ellipsis' で省略表示する。 */
+export function buildPaginationItems(
+  current: number,
+  total: number
+): Array<number | 'ellipsis'> {
+  if (total <= 1) return [1]
+  if (total <= 7) {
+    return Array.from({ length: total }, (_, i) => i + 1)
+  }
+
+  const set = new Set<number>()
+  set.add(1)
+  set.add(total)
+  for (let p = current - 1; p <= current + 1; p++) {
+    if (p >= 1 && p <= total) set.add(p)
+  }
+
+  const sorted = [...set].sort((a, b) => a - b)
+  const out: Array<number | 'ellipsis'> = []
+
+  for (let i = 0; i < sorted.length; i++) {
+    if (i > 0 && sorted[i] - sorted[i - 1] > 1) {
+      out.push('ellipsis')
+    }
+    out.push(sorted[i])
+  }
+
+  return out
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import path from 'path'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  envDir: '.',
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
# 概要
- アップデート ver 1.05

# 変更内容
- ダッシュボードの支出一覧を年月で指定できるように変更
- 年月毎に取得することで読込量を軽減
- グラフ押下時の遷移機能追加
- グラフのタグ表示機能追加
- テストコードの実装
- リファクタリング

# レビューチェックリスト
- [x] コードが実行可能である
- [x] 単体テスト / E2E テストを追加 or 既存テストをパス
- [x] lint エラーがない
- [x] 依存関係に不要な変更がない
- [x] ドキュメントを更新した（必要な場合）