### PR TITLE
feat: 予算・収入機能を追加し、Firestore読取コストを抑制

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -15,6 +15,30 @@
         { "fieldPath": "userId", "order": "ASCENDING" },
         { "fieldPath": "date", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "incomes",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "date", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "incomes",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "date", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "budgets",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "year", "order": "ASCENDING" },
+        { "fieldPath": "month", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.rules
+++ b/firestore.rules
@@ -7,6 +7,11 @@ service cloud.firestore {
       allow read, write: if request.auth != null;
     }
 
+    // 収入カテゴリーマスタ
+    match /incomeCategories/{categoryId} {
+      allow read, write: if request.auth != null;
+    }
+
     // tagsコレクション: 認証済みユーザーは読み書き可能
     match /tags/{tagId} {
       allow read, write: if request.auth != null;
@@ -14,6 +19,12 @@ service cloud.firestore {
 
     // expensesコレクション: 自分のデータのみ読み書き可能
     match /expenses/{expenseId} {
+      allow read, write: if request.auth != null && request.auth.uid == resource.data.userId;
+      allow create: if request.auth != null && request.auth.uid == request.resource.data.userId;
+    }
+
+    // incomesコレクション: 自分のデータのみ読み書き可能
+    match /incomes/{incomeId} {
       allow read, write: if request.auth != null && request.auth.uid == resource.data.userId;
       allow create: if request.auth != null && request.auth.uid == request.resource.data.userId;
     }
@@ -28,8 +39,20 @@ service cloud.firestore {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }
 
-    // その他のコレクション: 認証済みユーザーのみアクセス可能（必要に応じて調整）
-    match /{document=**} {
+    // 月次収入合計
+    match /users/{userId}/monthlyIncomeTotals/{periodId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
+    // 月次予算（本人のみ）
+    match /users/{userId}/budgets/{budgetId} {
+      allow read, update, delete: if request.auth != null && request.auth.uid == userId;
+      allow create: if request.auth != null && request.auth.uid == userId
+        && request.resource.data.userId == userId;
+    }
+
+    // 支払い方法マスタ
+    match /paymentMethods/{paymentMethodId} {
       allow read, write: if request.auth != null;
     }
   }

--- a/notes/budget-feature-design.md
+++ b/notes/budget-feature-design.md
@@ -16,14 +16,16 @@
 
 ### 2.1 本設計で想定する範囲
 
-| 項目 | 内容 |
-|------|------|
-| 予算の単位 | **暦月**（`year` + `month`）。ダッシュボードの年月選択と一致。 |
-| 予算の粒度 | **月次の合計**、**カテゴリー別**、**タグ別**（同一月に、全体1件＋カテゴリー／タグごと複数を許容。タグはマスタの **`tags/{tagId}`** を主キーにし、支出のタグ文字列と突き合わせる）。 |
-| 設定UI | 専用の簡易画面（ページ遷移とクエリの関係は実装時に整理）。 |
-| 表示 | ダッシュボードで **使用額／予算上限の比率をプログレスバー** で示し、**残り金額**（および超過時は超過分）を数値でも併記。超過時は色・アイコンに加え、`aria-*` 等でアクセシブルに。 |
+
+| 項目         | 内容                                                                                                                                                     |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 予算の単位      | **暦月**（`year` + `month`）。ダッシュボードの年月選択と一致。                                                                                                              |
+| 予算の粒度      | **月次の合計**、**カテゴリー別**、**タグ別**（同一月に、全体1件＋カテゴリー／タグごと複数を許容。タグはマスタの `**tags/{tagId}`** を主キーにし、支出のタグ文字列と突き合わせる）。                                             |
+| 設定UI       | 専用の簡易画面（ページ遷移とクエリの関係は実装時に整理）。                                                                                                                          |
+| 表示         | ダッシュボードで **使用額／予算上限の比率をプログレスバー** で示し、**残り金額**（および超過時は超過分）を数値でも併記。超過時は色・アイコンに加え、`aria-`* 等でアクセシブルに。                                                     |
 | 予算フォームの初期値 | **前月**（`year`/`month` が直前の暦月）に、同じ予算枠（全体／同一 `categoryId`／同一 `tagId`）として保存済みの `amountLimit` があれば、**翌月（または設定しようとしている月）の入力欄の初期値**としてその金額を流用する。前月に未設定の枠は空欄。 |
-| 永続化 | Firestore、**本人のみ読み書き**。 |
+| 永続化        | Firestore、**本人のみ読み書き**。                                                                                                                                |
+
 
 ### 2.2 将来拡張
 
@@ -38,6 +40,7 @@
 2. ダッシュボードで 4 月を表示しているとき、**当月支出合計**（既存の `monthlyTotal` 相当）と予算上限を比較し、**プログレスバー**で消化率を示し、**残り ¥○○**（超過時はマイナスまたは「¥○○ 超過」）を併記する。カテゴリー別は **該当 `bigCategory` の実績合計**、タグ別は **そのタグを含む支出の按分／合算ルール**（実装で固定）と各予算を比較する。
 3. 5 月に予算を初めて設定する画面を開いたとき、**4 月に保存済みの同じ枠**（全体・各カテゴリー・各タグ）の金額が入力欄の**初期値**として入っている（前月未設定の行は空欄）。
 4. 合計が予算を超えた場合、視覚的に「超過」を示す（アクセシビリティ: 色だけに依存しない）。
+
 > **注（「前日」表記について）**  
 > 本設計では **暦月の「前月」**（設定しようとしている月の直前の月）に保存した `amountLimit` を、**翌月＝次に設定する月のフォーム初期値**に流用する仕様とする。日単位の「前日」コピーは行わない。日次要件が必要なら別途化する。
 
@@ -51,25 +54,29 @@ Firestore の **コレクション ID**（パス上のセグメント名）を�
 
 #### ルート直下（既存アプリ）
 
-| コレクション ID | 典型パス | 用途 |
-|-----------------|----------|------|
-| `categories` | `categories/{categoryId}` | カテゴリーマスタ |
-| `tags` | `tags/{tagId}` | タグマスタ |
-| `expenses` | `expenses/{expenseId}` | 支出（`userId` で本人のみアクセス） |
-| `users` | `users/{userId}` | ユーザードキュメント（プロフィール等）。**サブコレクションの親** |
+
+| コレクション ID    | 典型パス                      | 用途                                 |
+| ------------ | ------------------------- | ---------------------------------- |
+| `categories` | `categories/{categoryId}` | カテゴリーマスタ                           |
+| `tags`       | `tags/{tagId}`            | タグマスタ                              |
+| `expenses`   | `expenses/{expenseId}`    | 支出（`userId` で本人のみアクセス）             |
+| `users`      | `users/{userId}`          | ユーザードキュメント（プロフィール等）。**サブコレクションの親** |
+
 
 #### `users/{userId}` 直下のサブコレクション
 
-| コレクション ID | 典型パス | 用途 |
-|-----------------|----------|------|
-| `monthlyTotals` | `users/{userId}/monthlyTotals/{periodId}` | 月次支出合計キャッシュ（既存） |
-| `budgets` | `users/{userId}/budgets/{budgetDocId}` | **予算（本機能・推奨）**。`budgetDocId` は §4.1 の `periodId` / `periodId__cat__{categoryId}` / `periodId__tag__{tagId}` 等 |
+
+| コレクション ID       | 典型パス                                      | 用途                                                                                                            |
+| --------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `monthlyTotals` | `users/{userId}/monthlyTotals/{periodId}` | 月次支出合計キャッシュ（既存）                                                                                               |
+| `budgets`       | `users/{userId}/budgets/{budgetDocId}`    | **予算（本機能）**。`budgetDocId` は §4.1 の `periodId` / `periodId__cat__{categoryId}` / `periodId__tag__{tagId}` |
+
 
 ---
 
-### 4.1 推奨パス（月次・ユーザー配下）
+### 4.1 パスとドキュメント ID（採用）
 
-既存の `users/{userId}/monthlyTotals/{periodId}` と並べて管理すると、ルールとクエリの一貫性が取りやすい。
+本アプリでは **`users/{userId}/budgets` 直下に月次予算をフラットに格納**する。既存の `users/{userId}/monthlyTotals/{periodId}` と並べて管理すると、ルールとクエリの一貫性が取りやすい。
 
 **月次の「全体合計」予算（1ユーザー・1月・1ドキュメント）**
 
@@ -77,7 +84,7 @@ Firestore の **コレクション ID**（パス上のセグメント名）を�
 users/{userId}/budgets/{periodId}
 ```
 
-- **`periodId`**: 既存の月次合計と同形式を推奨（例: `2026_04`）。`expenseService` の `monthlyTotalPeriodId(year, month)` と揃える。
+- **`periodId`**: 既存の月次合計と同形式（例: `2026_04`）。`expenseService` の `monthlyTotalPeriodId(year, month)` と揃える。
 
 **同一月の「カテゴリー別」予算（カテゴリーごとに1ドキュメント）**
 
@@ -85,7 +92,7 @@ users/{userId}/budgets/{periodId}
 users/{userId}/budgets/{periodId}__cat__{categoryId}
 ```
 
-- ドキュメント ID に `categoryId` を含める **パターン A**。一覧は `collectionGroup` や `year`/`month` フィールドでのクエリ設計が必要になる場合あり。
+- 一覧・前月初期値取得は、同一サブコレクションに対する `where('year', '==', year)` と `where('month', '==', month)` のクエリ（複合インデックス）で行う。
 
 **同一月の「タグ別」予算（タグごとに1ドキュメント）**
 
@@ -93,31 +100,25 @@ users/{userId}/budgets/{periodId}__cat__{categoryId}
 users/{userId}/budgets/{periodId}__tag__{tagId}
 ```
 
-- `tagId` は **`tags` コレクションのドキュメント ID**（`Tag.id`）。タグ名の衝突や改名には **ID を主**、`tagName` はフィールドで冗長保持（§4.1 フィールド表）。
+- `tagId` は **`tags` コレクションのドキュメント ID**（`Tag.id`）。タグ名の衝突や改名には **ID を主**、`tagName` はフィールドで冗長保持（下記フィールド表）。
 - 実績側は `Expense.tags`（カンマ区切り文字列）と突き合わせるため、比較時は **`tags/{tagId}.name`** と一致するか、または保存時に正規化ルールを固定する。
 
-**サブコレクションで月内をまとめる例（パターン B・一覧向け）**
+**フィールド案（全体・カテゴリー別・タグ別で共通スキーマ）**
 
-```
-users/{userId}/budgets/{periodId}/items/{itemId}
-```
 
-- `itemId` 例: `total`（全体） / `cat_{categoryId}`（カテゴリー別） / `tag_{tagId}`（タグ別）。
+| フィールド          | 型             | 必須  | 説明                                                                         |
+| -------------- | ------------- | --- | -------------------------------------------------------------------------- |
+| `userId`       | string        | ○   | 冗長でもルール検証に使える                                                              |
+| `year`         | number        | ○   |                                                                            |
+| `month`        | number        | ○   | 1–12                                                                       |
+| `amountLimit`  | number        | ○   | 予算上限（円）。0 以上の整数推奨                                                          |
+| `categoryId`   | string | null | ×   | **カテゴリー別予算のとき必須**（`categories` のドキュメント ID）。全体・タグのみのとき **null**。            |
+| `categoryName` | string | null | ×   | 表示・`Expense.bigCategory` 突き合わせ用。カテゴリー別のときマスタの `Category.name` と一致させる。      |
+| `tagId`        | string | null | ×   | **タグ別予算のとき必須**（`tags` のドキュメント ID）。全体・カテゴリーのみのとき **null**。                  |
+| `tagName`      | string | null | ×   | 表示・`Expense.tags` 突き合わせ用の冗長フィールド。マスタの `Tag.name` と一致させ、改名時は **追随方針** を決める。 |
+| `updatedAt`    | Timestamp     | ○   |                                                                            |
+| `createdAt`    | Timestamp     | 任意  |                                                                            |
 
-- **フィールド案（全体・カテゴリー別・タグ別で共通スキーマ）**
-
-| フィールド | 型 | 必須 | 説明 |
-|-----------|-----|------|------|
-| `userId` | string | ○ | 冗長でもルール検証に使える |
-| `year` | number | ○ | |
-| `month` | number | ○ | 1–12 |
-| `amountLimit` | number | ○ | 予算上限（円）。0 以上の整数推奨 |
-| `categoryId` | string \| null | × | **カテゴリー別予算のとき必須**（`categories` のドキュメント ID）。全体・タグのみのとき **null**。 |
-| `categoryName` | string \| null | × | 表示・`Expense.bigCategory` 突き合わせ用。カテゴリー別のときマスタの `Category.name` と一致させる。 |
-| `tagId` | string \| null | × | **タグ別予算のとき必須**（`tags` のドキュメント ID）。全体・カテゴリーのみのとき **null**。 |
-| `tagName` | string \| null | × | 表示・`Expense.tags` 突き合わせ用の冗長フィールド。マスタの `Tag.name` と一致させ、改名時は **追随方針** を決める。 |
-| `updatedAt` | Timestamp | ○ | |
-| `createdAt` | Timestamp | 任意 | |
 
 **整合ルール（推奨）**
 
@@ -129,20 +130,20 @@ users/{userId}/budgets/{periodId}/items/{itemId}
 
 ### 4.2 トップレベル `budgets` コレクション（代替案）
 
-ルート直下に **`budgets`** コレクションを置き `budgets/{budgetDocId}` とする案（`expenses` と同列）。メリット: パスが短い。デメリット: 既存の `users/.../monthlyTotals` 等と親パターンが分かれる。
+ルート直下に `**budgets`** コレクションを置き `budgets/{budgetDocId}` とする案（`expenses` と同列）。メリット: パスが短い。デメリット: 既存の `users/.../monthlyTotals` 等と親パターンが分かれる。
 
-本アプリでは **サブコレクション `users/{uid}/budgets`**（§4.0）を推奨。
+本アプリでは **サブコレクション `users/{uid}/budgets`**（§4.0）を採用する。
 
 ---
 
 ## 5. セキュリティルール
 
-`users/{userId}/budgets/{document=**}`（`budgets` 直下および `budgets/{periodId}/items/...` など）に対し:
+`users/{userId}/budgets/{budgetId}` に対し:
 
 - `read`, `write`: `request.auth != null && request.auth.uid == userId`
 - `create` 時: `request.resource.data.userId == request.auth.uid` を要求すると安全
 
-既存の `users/{userId}/monthlyTotals/...` と同様のパターンに揃える（サブコレクションを使う場合はワイルドカードで網羅）。
+既存の `users/{userId}/monthlyTotals/...` と同様のパターンに揃える。
 
 ---
 
@@ -181,14 +182,14 @@ export interface MonthlyBudget {
 - `getMonthlyTotalBudget(userId, year, month): Promise<MonthlyBudget | null>`（全体: `categoryId` / `tagId` がともに null）
 - `getCategoryBudget(userId, year, month, categoryId): Promise<MonthlyBudget | null>`
 - `getTagBudget(userId, year, month, tagId): Promise<MonthlyBudget | null>`
-- `listBudgetsForMonth(userId, year, month): Promise<MonthlyBudget[]>`（一覧画面・前月からの初期値取得・パターン B では `items` 列挙）
+- `listBudgetsForMonth(userId, year, month): Promise<MonthlyBudget[]>`（一覧画面・前月からの初期値取得）
 - `setBudget(userId, year, month, amountLimit, options?: { categoryId?: string; categoryName?: string; tagId?: string; tagName?: string }): Promise<void>`（`setDoc` merge）。`options` 省略または空で全体予算。
 - バリデーション: 負数不可、カテゴリー別とタグ別を **同時に指定しない**、各モードでマスタ解決または `*Name` 必須、上限の実用的な最大値（任意）
 
 ### 7.3 フック（例: `useMonthlyBudget.ts`）
 
 - ダッシュボードの `selectedYearMonth` と連動して購読または都度取得。
-- `useDashboardExpenses` の `monthlyTotal` と組み合わせて **残額・使用率**（プログレスバー用の `used / limit`、表示用の `limit - used`）を `useMemo` で算出。カテゴリー別は `bigCategory`、タグ別は **`tags` の `tagName` と `Expense.tags`**（既存のカンマ区切りパース）で突合。複数タグ付き支出の按分ルールは MonthlySummary と揃えるか、タグ別は「そのタグを含む支出の全額をカウント」等を設計で固定する。
+- `useDashboardExpenses` の `monthlyTotal` と組み合わせて **残額・使用率**（プログレスバー用の `used / limit`、表示用の `limit - used`）を `useMemo` で算出。カテゴリー別は `bigCategory`、タグ別は `**tags` の `tagName` と `Expense.tags`**（既存のカンマ区切りパース）で突合。複数タグ付き支出の按分ルールは MonthlySummary と揃えるか、タグ別は「そのタグを含む支出の全額をカウント」等を設計で固定する。
 
 ### 7.4 UI
 
@@ -199,7 +200,7 @@ export interface MonthlyBudget {
   - 予算未設定時はバー非表示または「未設定」＋「予算を設定」リンク。
 - **設定画面**  
   - 数値入力 + 保存。年月は現在表示中の月をデフォルトにするか、明示選択。モード切替（全体 / カテゴリー / タグ）とマスタ連動のセレクト（既存フック流用可）。  
-  - **初期値（前月コピー）**: 画面表示中の `year`/`month` について **`month === 1` なら前年12月、それ以外なら同年 `month - 1`** を前月と定義し、その月の `budgets` を取得。取得した各 `MonthlyBudget` について、同じ種別（`categoryId` / `tagId` の組み合わせが一致）の行に `amountLimit` をフォーム初期値としてセット。全体予算は `categoryId`・`tagId` がともに null の1件を前月からコピー。  
+  - **初期値（前月コピー）**: 画面表示中の `year`/`month` について `**month === 1` なら前年12月、それ以外なら同年 `month - 1`** を前月と定義し、その月の `budgets` を取得。取得した各 `MonthlyBudget` について、同じ種別（`categoryId` / `tagId` の組み合わせが一致）の行に `amountLimit` をフォーム初期値としてセット。全体予算は `categoryId`・`tagId` がともに null の1件を前月からコピー。  
   - 前月データ取得は **読み取り追加のみ**（Firestore に「初期値用」フィールドは不要）。初回利用で前月が無い場合は空欄のまま。
 
 ### 7.5 ルーティング
@@ -210,13 +211,15 @@ export interface MonthlyBudget {
 
 ## 8. 既存機能との関係
 
-| 既存 | 関係 |
-|------|------|
-| `useDashboardExpenses` / `monthlyTotal` | 実績のソース。予算との差分表示に利用。 |
-| `users/.../monthlyTotals` | 集計キャッシュ。予算比較の「実績」は `monthlyTotal` を優先し、無い場合のフォールバック方針は既存ロジックに合わせる。 |
-| `bigCategory` / カテゴリーマスタ | 予算の `categoryName` / `categoryId` と実績を突き合わせる。 |
-| `tags` マスタ / `Expense.tags` | 予算の `tagId` / `tagName` と実績を突き合わせる。 |
-| 読取回数 | 予算は月あたり複数 doc の get／小さな一覧取得が中心。リアルタイムリスナーは任意。 |
+
+| 既存                                      | 関係                                                                 |
+| --------------------------------------- | ------------------------------------------------------------------ |
+| `useDashboardExpenses` / `monthlyTotal` | 実績のソース。予算との差分表示に利用。                                                |
+| `users/.../monthlyTotals`               | 集計キャッシュ。予算比較の「実績」は `monthlyTotal` を優先し、無い場合のフォールバック方針は既存ロジックに合わせる。 |
+| `bigCategory` / カテゴリーマスタ                | 予算の `categoryName` / `categoryId` と実績を突き合わせる。                      |
+| `tags` マスタ / `Expense.tags`             | 予算の `tagId` / `tagName` と実績を突き合わせる。                                |
+| 読取回数                                    | 予算は月あたり複数 doc の get／小さな一覧取得が中心。リアルタイムリスナーは任意。                      |
+
 
 ---
 
@@ -241,11 +244,15 @@ export interface MonthlyBudget {
 
 ## 11. 変更履歴
 
-| 日付 | 内容 |
-|------|------|
-| 2026-04-03 | 初版ドラフト作成 |
-| 2026-04-03 | 予算フィールドに `categoryId` / `categoryName` を追加。カテゴリー別のパス案・型・サービス API を追記 |
-| 2026-04-03 | MVP／第1・第2段階の区分を削除し、スコープを「本設計」と「将来拡張」に整理 |
-| 2026-04-03 | §4.0 に Firestore コレクション ID 一覧（既存＋`budgets`／任意 `items`）を追記 |
+
+| 日付         | 内容                                                                                       |
+| ---------- | ---------------------------------------------------------------------------------------- |
+| 2026-04-03 | 初版ドラフト作成                                                                                 |
+| 2026-04-03 | 予算フィールドに `categoryId` / `categoryName` を追加。カテゴリー別のパス案・型・サービス API を追記                     |
+| 2026-04-03 | MVP／第1・第2段階の区分を削除し、スコープを「本設計」と「将来拡張」に整理                                                  |
+| 2026-04-03 | §4.0 に Firestore コレクション ID 一覧（既存＋`budgets`）を追記                                |
+| 2026-04-03 | §4.1 から未採用のパス案（`budgets/{periodId}/items/...`）を削除し、採用パスに一本化                              |
 | 2026-04-03 | §2.1 にタグ別予算を組み込み。§4.1・§7・§8・§9・§10 を `tagId` / `tagName`・パス `periodId__tag__{tagId}` に整合 |
-| 2026-04-03 | 残りをプログレスバー主表示とし、前月の `amountLimit` を翌月（設定月）フォーム初期値に流用する仕様を §2.1・§3・§7 に追記 |
+| 2026-04-03 | 残りをプログレスバー主表示とし、前月の `amountLimit` を翌月（設定月）フォーム初期値に流用する仕様を §2.1・§3・§7 に追記                 |
+
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import CategoryTagManagement from './pages/CategoryTagManagement/CategoryTagMana
 import MonthlyExpenses from './pages/MonthlyExpenses/MonthlyExpenses'
 import MonthlySummary from './pages/MonthlySummary/MonthlySummary'
 import Profile from './pages/Profile/Profile'
+import Budget from './pages/Budget/Budget'
 import ProtectedRoute from './components/ProtectedRoute'
 import './App.css'
 
@@ -64,6 +65,14 @@ function App() {
           element={
             <ProtectedRoute>
               <Profile />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/budget"
+          element={
+            <ProtectedRoute>
+              <Budget />
             </ProtectedRoute>
           }
         />

--- a/src/components/BudgetProgressBar.css
+++ b/src/components/BudgetProgressBar.css
@@ -1,0 +1,100 @@
+.budget-progress {
+  width: 100%;
+  max-width: 28rem;
+  margin-top: 0.75rem;
+}
+
+.budget-progress--loading {
+  margin: 0;
+  font-size: 0.9rem;
+  opacity: 0.9;
+}
+
+.budget-progress--unset {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.budget-progress-unset-text {
+  margin: 0;
+  font-size: 0.9rem;
+  opacity: 0.95;
+}
+
+.budget-progress-settings-link {
+  display: inline-block;
+  padding: 0.45rem 0.9rem;
+  background-color: rgba(255, 255, 255, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  border-radius: 0.5rem;
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.85rem;
+  text-decoration: none;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.budget-progress-settings-link:hover {
+  background-color: rgba(255, 255, 255, 0.3);
+  border-color: rgba(255, 255, 255, 0.65);
+}
+
+.budget-progress-track {
+  position: relative;
+  height: 0.65rem;
+  border-radius: 999px;
+  background-color: rgba(255, 255, 255, 0.25);
+  overflow: hidden;
+}
+
+.budget-progress-track--over {
+  outline: 2px solid #fbbf24;
+  outline-offset: 2px;
+}
+
+.budget-progress-fill {
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #34d399 0%, #10b981 100%);
+  transition: width 0.25s ease;
+}
+
+.budget-progress-track--over .budget-progress-fill {
+  background: linear-gradient(90deg, #fbbf24 0%, #f97316 100%);
+}
+
+.budget-progress-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 1rem;
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.budget-progress-remaining {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.budget-progress-over-icon {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.budget-progress-rate {
+  opacity: 0.85;
+  font-weight: 500;
+}
+
+.budget-progress-settings-link--inline {
+  margin-left: auto;
+}
+
+.budget-progress--active {
+  position: relative;
+}

--- a/src/components/BudgetProgressBar.test.tsx
+++ b/src/components/BudgetProgressBar.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '../test/testUtils'
+import { BudgetProgressBar } from './BudgetProgressBar'
+
+describe('BudgetProgressBar', () => {
+  it('shows unset message and settings link when limit is null', () => {
+    render(
+      <BudgetProgressBar used={0} limit={null} budgetSettingsTo="/budget?year=2026&month=4" />
+    )
+    expect(screen.getByText(/予算はまだ設定されていません/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: '予算を設定' })).toHaveAttribute(
+      'href',
+      '/budget?year=2026&month=4'
+    )
+  })
+
+  it('shows progressbar and remaining when under budget', () => {
+    render(
+      <BudgetProgressBar used={40_000} limit={100_000} budgetSettingsTo="/budget?year=2026&month=4" />
+    )
+    const bar = screen.getByRole('progressbar')
+    expect(bar).toHaveAttribute('aria-valuenow', '40')
+    expect(screen.getByText(/残り/)).toBeInTheDocument()
+    expect(screen.getByText(/60/)).toBeInTheDocument()
+  })
+
+  it('includes carry-in in available budget', () => {
+    render(
+      <BudgetProgressBar
+        used={40_000}
+        limit={100_000}
+        carryIn={20_000}
+        budgetSettingsTo="/budget"
+      />
+    )
+    // 40/120 ≈ 33%
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '33')
+    expect(screen.getByText(/繰越/)).toBeInTheDocument()
+    expect(screen.getByText(/残り/)).toBeInTheDocument()
+  })
+
+  it('includes negative carry-in in available budget', () => {
+    render(
+      <BudgetProgressBar
+        used={40_000}
+        limit={100_000}
+        carryIn={-20_000}
+        budgetSettingsTo="/budget"
+      />
+    )
+    // 40/80 = 50%
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '50')
+    expect(screen.getByText(/繰越/)).toBeInTheDocument()
+  })
+
+  it('shows over state when used exceeds limit', () => {
+    render(
+      <BudgetProgressBar used={120_000} limit={100_000} budgetSettingsTo="/budget" />
+    )
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '100')
+    expect(screen.getByText(/超過/)).toBeInTheDocument()
+  })
+
+  it('shows loading text when loading', () => {
+    render(
+      <BudgetProgressBar used={0} limit={100_000} loading budgetSettingsTo="/budget" />
+    )
+    expect(screen.getByText(/予算を読み込み中/)).toBeInTheDocument()
+  })
+})

--- a/src/components/BudgetProgressBar.tsx
+++ b/src/components/BudgetProgressBar.tsx
@@ -1,0 +1,113 @@
+import { Link } from 'react-router-dom'
+import './BudgetProgressBar.css'
+
+export type BudgetProgressBarProps = {
+  /** 当月の支出合計（円） */
+  used: number
+  /** 月次予算の上限（円）。null は未設定 */
+  limit: number | null
+  /** 前月からの繰入（円） */
+  carryIn?: number
+  loading?: boolean
+  /** 予算設定ページへのパス（クエリ付き可） */
+  budgetSettingsTo: string
+}
+
+function formatYen(n: number): string {
+  return `¥${Math.round(n).toLocaleString()}`
+}
+
+/**
+ * ダッシュボード用：全体予算（＋繰入）に対する消化率と残り／超過を表示する。
+ */
+export function BudgetProgressBar({
+  used,
+  limit,
+  carryIn = 0,
+  loading,
+  budgetSettingsTo,
+}: BudgetProgressBarProps) {
+  if (loading) {
+    return (
+      <p className="budget-progress budget-progress--loading" aria-live="polite">
+        予算を読み込み中…
+      </p>
+    )
+  }
+
+  if (limit === null || limit <= 0) {
+    return (
+      <div className="budget-progress budget-progress--unset">
+        <p className="budget-progress-unset-text" id="budget-progress-unset-desc">
+          この月の予算はまだ設定されていません。
+        </p>
+        <Link
+          to={budgetSettingsTo}
+          className="budget-progress-settings-link"
+          aria-describedby="budget-progress-unset-desc"
+        >
+          予算を設定
+        </Link>
+      </div>
+    )
+  }
+
+  const safeCarryIn = carryIn
+  const available = limit + safeCarryIn
+  const ratio = available > 0 ? used / available : used > 0 ? Number.POSITIVE_INFINITY : 0
+  const over = used > available
+  const barPct =
+    available > 0 ? Math.min(100, (used / available) * 100) : used > 0 ? 100 : 0
+  const ariaValuenow = available > 0 ? Math.round(Math.min(100, (used / available) * 100)) : over ? 100 : 0
+  const remaining = available - used
+  const carryLabel =
+    safeCarryIn === 0
+      ? ''
+      : safeCarryIn > 0
+        ? ` + 繰越 ${formatYen(safeCarryIn)}`
+        : ` − 繰越不足 ${formatYen(Math.abs(safeCarryIn))}`
+  const statusText = over
+    ? `${formatYen(used - available)} 超過。有効予算 ${formatYen(available)}（予算 ${formatYen(limit)}${carryLabel}）、使用額 ${formatYen(used)}。`
+    : `残り ${formatYen(remaining)}。有効予算 ${formatYen(available)}（予算 ${formatYen(limit)}${carryLabel}）、使用額 ${formatYen(used)}。`
+
+  return (
+    <div className="budget-progress budget-progress--active">
+      <div
+        className={`budget-progress-track ${over ? 'budget-progress-track--over' : ''}`}
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={over ? 100 : ariaValuenow}
+        aria-label="月全体の有効予算に対する支出の割合"
+        aria-valuetext={statusText}
+      >
+        <div className="budget-progress-fill" style={{ width: `${barPct}%` }} />
+      </div>
+      <div className="budget-progress-meta">
+        <span className="budget-progress-remaining" aria-live="polite">
+          {over ? (
+            <>
+              <span className="budget-progress-over-icon" aria-hidden="true">
+                ⚠
+              </span>
+              <span>{formatYen(used - available)} 超過</span>
+            </>
+          ) : (
+            <span>残り {formatYen(remaining)}</span>
+          )}
+        </span>
+        <span className="budget-progress-rate" aria-hidden="true">
+          {Number.isFinite(ratio) ? `${Math.round(ratio * 100)}% 使用` : '—'}
+          {safeCarryIn > 0
+            ? ` · 繰越 ${formatYen(safeCarryIn)}`
+            : safeCarryIn < 0
+              ? ` · 繰越 ${formatYen(safeCarryIn)}`
+              : ''}
+        </span>
+        <Link to={budgetSettingsTo} className="budget-progress-settings-link budget-progress-settings-link--inline">
+          予算を編集
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/src/components/BudgetScopedProgress.css
+++ b/src/components/BudgetScopedProgress.css
@@ -1,0 +1,118 @@
+.budget-scoped {
+  width: 100%;
+  max-width: 28rem;
+  margin-top: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.budget-scoped--loading {
+  margin: 1rem 0 0;
+  font-size: 0.9rem;
+  opacity: 0.9;
+}
+
+.budget-scoped-section {
+  margin: 0;
+}
+
+.budget-scoped-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.65rem;
+}
+
+.budget-scoped-title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: inherit;
+}
+
+.budget-scoped-edit-link {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: inherit;
+  opacity: 0.9;
+  text-decoration: underline;
+}
+
+.budget-scoped-edit-link:hover {
+  opacity: 1;
+}
+
+.budget-scoped-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.budget-scoped-row-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.35rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.budget-scoped-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.budget-scoped-amounts {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.budget-scoped-over-icon {
+  font-size: 0.95rem;
+  line-height: 1;
+}
+
+.budget-scoped-track {
+  height: 0.5rem;
+  border-radius: 999px;
+  background-color: rgba(255, 255, 255, 0.25);
+  overflow: hidden;
+}
+
+.budget-scoped-track--over {
+  outline: 2px solid #fbbf24;
+  outline-offset: 1px;
+}
+
+.budget-scoped-fill {
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #6ee7b7 0%, #34d399 100%);
+  transition: width 0.25s ease;
+}
+
+.budget-scoped-track--over .budget-scoped-fill {
+  background: linear-gradient(90deg, #fbbf24 0%, #f97316 100%);
+}
+
+.budget-scoped-meta {
+  margin: 0.3rem 0 0;
+  font-size: 0.8rem;
+  font-weight: 500;
+  opacity: 0.85;
+}
+
+.budget-scoped-row--over .budget-scoped-amounts {
+  color: #fef3c7;
+}

--- a/src/components/BudgetScopedProgress.test.tsx
+++ b/src/components/BudgetScopedProgress.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '../test/testUtils'
+import { Timestamp } from 'firebase/firestore'
+import { BudgetScopedProgress } from './BudgetScopedProgress'
+import type { Expense, MonthlyBudget } from '../types'
+
+const ts = Timestamp.now()
+
+const expenses: Expense[] = [
+  {
+    id: '1',
+    date: ts,
+    amount: 4000,
+    userId: 'u1',
+    bigCategory: '食費',
+    tags: 'ランチ',
+    paymentMethod: '',
+    description: '',
+    createdAt: ts,
+    updatedAt: ts,
+  },
+]
+
+const categoryBudgets: MonthlyBudget[] = [
+  {
+    id: 'c',
+    userId: 'u1',
+    year: 2026,
+    month: 4,
+    amountLimit: 10000,
+    categoryId: 'cat1',
+    categoryName: '食費',
+    tagId: null,
+    tagName: null,
+    updatedAt: ts,
+  },
+]
+
+const tagBudgets: MonthlyBudget[] = [
+  {
+    id: 't',
+    userId: 'u1',
+    year: 2026,
+    month: 4,
+    amountLimit: 3000,
+    categoryId: null,
+    categoryName: null,
+    tagId: 'tag1',
+    tagName: 'ランチ',
+    updatedAt: ts,
+  },
+]
+
+describe('BudgetScopedProgress', () => {
+  it('renders nothing when no scoped budgets', () => {
+    const { container } = render(
+      <BudgetScopedProgress
+        expenses={expenses}
+        categoryBudgets={[]}
+        tagBudgets={[]}
+        budgetSettingsTo="/budget"
+      />
+    )
+    expect(container.querySelector('.budget-scoped')).toBeNull()
+  })
+
+  it('shows category and tag progress with remaining/over', () => {
+    render(
+      <BudgetScopedProgress
+        expenses={expenses}
+        categoryBudgets={categoryBudgets}
+        tagBudgets={tagBudgets}
+        budgetSettingsTo="/budget?year=2026&month=4"
+      />
+    )
+    expect(screen.getByText('カテゴリー別予算')).toBeInTheDocument()
+    expect(screen.getByText('タグ別予算')).toBeInTheDocument()
+    expect(screen.getByText('食費')).toBeInTheDocument()
+    expect(screen.getByText('ランチ')).toBeInTheDocument()
+    expect(screen.getByText(/残り/)).toBeInTheDocument()
+    expect(screen.getByText(/超過/)).toBeInTheDocument()
+    expect(screen.getAllByRole('progressbar')).toHaveLength(2)
+  })
+
+  it('shows loading text', () => {
+    render(
+      <BudgetScopedProgress
+        expenses={[]}
+        categoryBudgets={[]}
+        tagBudgets={[]}
+        loading
+        budgetSettingsTo="/budget"
+      />
+    )
+    expect(screen.getByText(/カテゴリー・タグ予算を読み込み中/)).toBeInTheDocument()
+  })
+})

--- a/src/components/BudgetScopedProgress.tsx
+++ b/src/components/BudgetScopedProgress.tsx
@@ -1,0 +1,130 @@
+import { Link } from 'react-router-dom'
+import type { Expense, MonthlyBudget } from '../types'
+import { buildScopedBudgetProgress } from '../utils/budgetSpentBreakdown'
+import './BudgetScopedProgress.css'
+
+export type BudgetScopedProgressProps = {
+  expenses: Expense[]
+  categoryBudgets: MonthlyBudget[]
+  tagBudgets: MonthlyBudget[]
+  loading?: boolean
+  budgetSettingsTo: string
+}
+
+function formatYen(n: number): string {
+  const abs = Math.round(Math.abs(n)).toLocaleString()
+  return n < 0 ? `−¥${abs}` : `¥${abs}`
+}
+
+/**
+ * ダッシュボード用：カテゴリー別・タグ別予算の消化状況。
+ */
+export function BudgetScopedProgress({
+  expenses,
+  categoryBudgets,
+  tagBudgets,
+  loading,
+  budgetSettingsTo,
+}: BudgetScopedProgressProps) {
+  if (loading) {
+    return (
+      <p className="budget-scoped budget-scoped--loading" aria-live="polite">
+        カテゴリー・タグ予算を読み込み中…
+      </p>
+    )
+  }
+
+  const rows = buildScopedBudgetProgress([...categoryBudgets, ...tagBudgets], expenses)
+  if (rows.length === 0) {
+    return null
+  }
+
+  const categories = rows.filter((r) => r.kind === 'category')
+  const tags = rows.filter((r) => r.kind === 'tag')
+
+  return (
+    <div className="budget-scoped">
+      {categories.length > 0 && (
+        <section className="budget-scoped-section" aria-labelledby="budget-scoped-cat-heading">
+          <div className="budget-scoped-head">
+            <h3 id="budget-scoped-cat-heading" className="budget-scoped-title">
+              カテゴリー別予算
+            </h3>
+            <Link to={budgetSettingsTo} className="budget-scoped-edit-link">
+              編集
+            </Link>
+          </div>
+          <ul className="budget-scoped-list">
+            {categories.map((row) => (
+              <ScopedRow key={row.key} row={row} />
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {tags.length > 0 && (
+        <section className="budget-scoped-section" aria-labelledby="budget-scoped-tag-heading">
+          <div className="budget-scoped-head">
+            <h3 id="budget-scoped-tag-heading" className="budget-scoped-title">
+              タグ別予算
+            </h3>
+            <Link to={budgetSettingsTo} className="budget-scoped-edit-link">
+              編集
+            </Link>
+          </div>
+          <ul className="budget-scoped-list">
+            {tags.map((row) => (
+              <ScopedRow key={row.key} row={row} />
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  )
+}
+
+function ScopedRow({
+  row,
+}: {
+  row: ReturnType<typeof buildScopedBudgetProgress>[number]
+}) {
+  const barPct = Number.isFinite(row.ratio) ? Math.min(100, row.ratio * 100) : 100
+  const statusText = row.over
+    ? `${formatYen(row.used - row.limit)} 超過。上限 ${formatYen(row.limit)}、使用 ${formatYen(row.used)}。`
+    : `残り ${formatYen(row.remaining)}。上限 ${formatYen(row.limit)}、使用 ${formatYen(row.used)}。`
+
+  return (
+    <li className={`budget-scoped-row${row.over ? ' budget-scoped-row--over' : ''}`}>
+      <div className="budget-scoped-row-top">
+        <span className="budget-scoped-label">{row.label}</span>
+        <span className="budget-scoped-amounts" aria-live="polite">
+          {row.over ? (
+            <>
+              <span className="budget-scoped-over-icon" aria-hidden="true">
+                ⚠
+              </span>
+              {formatYen(row.used - row.limit)} 超過
+            </>
+          ) : (
+            <>残り {formatYen(row.remaining)}</>
+          )}
+        </span>
+      </div>
+      <div
+        className={`budget-scoped-track${row.over ? ' budget-scoped-track--over' : ''}`}
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={row.over ? 100 : Math.round(barPct)}
+        aria-label={`${row.kind === 'category' ? 'カテゴリー' : 'タグ'}「${row.label}」の予算消化率`}
+        aria-valuetext={statusText}
+      >
+        <div className="budget-scoped-fill" style={{ width: `${barPct}%` }} />
+      </div>
+      <p className="budget-scoped-meta">
+        {formatYen(row.used)} / {formatYen(row.limit)}
+        {Number.isFinite(row.ratio) ? `（${Math.round(row.ratio * 100)}%）` : ''}
+      </p>
+    </li>
+  )
+}

--- a/src/components/CategoryForm.tsx
+++ b/src/components/CategoryForm.tsx
@@ -3,14 +3,31 @@ import { categoryService } from '../services/categoryService'
 import type { Category } from '../types'
 import './CategoryForm.css'
 
+type CategoryApi = {
+  createCategory: (input: { name: string }) => Promise<string>
+  updateCategory: (categoryId: string, input: { name: string }) => Promise<void>
+}
+
 interface CategoryFormProps {
   categories: Category[]
   onSuccess: () => void
   editingCategory?: Category | null
   onCancel?: () => void
+  /** 省略時は支出カテゴリー */
+  api?: CategoryApi
+  namePlaceholder?: string
+  inputId?: string
 }
 
-export const CategoryForm = ({ categories, onSuccess, editingCategory, onCancel }: CategoryFormProps) => {
+export const CategoryForm = ({
+  categories,
+  onSuccess,
+  editingCategory,
+  onCancel,
+  api = categoryService,
+  namePlaceholder = '例: 食費',
+  inputId = 'categoryName',
+}: CategoryFormProps) => {
   const [categoryName, setCategoryName] = useState<string>('')
   const [submitting, setSubmitting] = useState<boolean>(false)
 
@@ -33,7 +50,7 @@ export const CategoryForm = ({ categories, onSuccess, editingCategory, onCancel 
     setSubmitting(true)
     try {
       const existingCategory = categories.find(
-        (cat) => 
+        (cat) =>
           cat.id !== editingCategory?.id &&
           cat.name.toLowerCase() === categoryName.trim().toLowerCase()
       )
@@ -45,16 +62,14 @@ export const CategoryForm = ({ categories, onSuccess, editingCategory, onCancel 
       }
 
       if (editingCategory) {
-        // 編集モード
-        await categoryService.updateCategory(editingCategory.id, { name: categoryName.trim() })
+        await api.updateCategory(editingCategory.id, { name: categoryName.trim() })
         alert('カテゴリーを更新しました')
       } else {
-        // 作成モード
-        await categoryService.createCategory({ name: categoryName.trim() })
+        await api.createCategory({ name: categoryName.trim() })
         setCategoryName('')
         alert('カテゴリーを追加しました')
       }
-      
+
       onSuccess()
     } catch (error) {
       console.error('Failed to save category', error)
@@ -65,27 +80,24 @@ export const CategoryForm = ({ categories, onSuccess, editingCategory, onCancel 
   }
 
   return (
-    <form className="management-form" onSubmit={handleSubmit}>
+    <form className="management-form" onSubmit={(e) => void handleSubmit(e)}>
       <div className="form-group">
-        <label htmlFor="categoryName">カテゴリー名 <span className="required">*</span></label>
+        <label htmlFor={inputId}>
+          カテゴリー名 <span className="required">*</span>
+        </label>
         <input
           type="text"
-          id="categoryName"
+          id={inputId}
           value={categoryName}
           onChange={(e) => setCategoryName(e.target.value)}
-          placeholder="例: 食費"
+          placeholder={namePlaceholder}
           required
           disabled={submitting}
         />
       </div>
       <div className="form-actions">
         {editingCategory && onCancel ? (
-          <button
-            type="button"
-            className="cancel-button"
-            onClick={onCancel}
-            disabled={submitting}
-          >
+          <button type="button" className="cancel-button" onClick={onCancel} disabled={submitting}>
             キャンセル
           </button>
         ) : (
@@ -99,12 +111,15 @@ export const CategoryForm = ({ categories, onSuccess, editingCategory, onCancel 
           </button>
         )}
         <button type="submit" className="submit-button" disabled={submitting}>
-          {submitting 
-            ? (editingCategory ? '更新中...' : '作成中...') 
-            : (editingCategory ? '更新' : '作成')}
+          {submitting
+            ? editingCategory
+              ? '更新中...'
+              : '作成中...'
+            : editingCategory
+              ? '更新'
+              : '作成'}
         </button>
       </div>
     </form>
   )
 }
-

--- a/src/components/IncomeCategoryModal.tsx
+++ b/src/components/IncomeCategoryModal.tsx
@@ -1,0 +1,129 @@
+import { useState, useEffect } from 'react'
+import { incomeCategoryService } from '../services/incomeCategoryService'
+import type { Category } from '../types'
+import './CategoryModal.css'
+
+interface IncomeCategoryModalProps {
+  category: Category | null
+  categories: Category[]
+  onClose: () => void
+  onSuccess: () => void
+}
+
+export const IncomeCategoryModal = ({
+  category,
+  categories,
+  onClose,
+  onSuccess,
+}: IncomeCategoryModalProps) => {
+  const [categoryName, setCategoryName] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    setCategoryName(category?.name ?? '')
+  }, [category])
+
+  if (!category) return null
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!categoryName.trim()) {
+      alert('カテゴリー名を入力してください')
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      const existing = categories.find(
+        (cat) =>
+          cat.id !== category.id && cat.name.toLowerCase() === categoryName.trim().toLowerCase()
+      )
+      if (existing) {
+        alert('同じ名前のカテゴリーが既に存在します')
+        setSubmitting(false)
+        return
+      }
+
+      await incomeCategoryService.updateCategory(category.id, { name: categoryName.trim() })
+      alert('カテゴリーを更新しました')
+      onSuccess()
+      onClose()
+    } catch (error) {
+      console.error('Failed to update income category', error)
+      alert('カテゴリーの更新に失敗しました')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (
+      !window.confirm(
+        `「${category.name}」を削除しますか？\n既に登録済みの収入のカテゴリー名はそのまま残ります。`
+      )
+    ) {
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      await incomeCategoryService.deleteCategory(category.id)
+      alert('カテゴリーを削除しました')
+      onSuccess()
+      onClose()
+    } catch (error) {
+      console.error('Failed to delete income category', error)
+      alert('カテゴリーの削除に失敗しました')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="category-modal-overlay" onClick={onClose}>
+      <div className="category-modal-content" onClick={(e) => e.stopPropagation()}>
+        <div className="category-modal-header">
+          <h2>収入カテゴリーの編集</h2>
+          <button type="button" className="category-modal-close" onClick={onClose}>
+            ×
+          </button>
+        </div>
+
+        <form className="category-modal-form" onSubmit={(e) => void handleSubmit(e)}>
+          <div className="form-group">
+            <label htmlFor="income-category-edit-name">
+              カテゴリー名 <span className="required">*</span>
+            </label>
+            <input
+              type="text"
+              id="income-category-edit-name"
+              value={categoryName}
+              onChange={(e) => setCategoryName(e.target.value)}
+              required
+              disabled={submitting}
+            />
+          </div>
+
+          <div className="category-modal-actions">
+            <button
+              type="button"
+              className="delete-button"
+              disabled={submitting}
+              onClick={() => void handleDelete()}
+            >
+              削除
+            </button>
+            <div className="action-buttons-right">
+              <button type="button" className="cancel-button" onClick={onClose} disabled={submitting}>
+                キャンセル
+              </button>
+              <button type="submit" className="submit-button" disabled={submitting}>
+                {submitting ? '保存中…' : '保存'}
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/components/IncomeForm.tsx
+++ b/src/components/IncomeForm.tsx
@@ -1,0 +1,133 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useIncomeMutations } from '../hooks/useIncomeMutations'
+import { useIncomeCategories } from '../hooks/useIncomeCategories'
+import { getInitialIncomeFormData } from '../utils/formUtils'
+import './ExpenseForm.css'
+
+interface IncomeFormProps {
+  userId: string
+  onSuccess: () => void
+}
+
+export const IncomeForm = ({ userId, onSuccess }: IncomeFormProps) => {
+  const [formData, setFormData] = useState(getInitialIncomeFormData())
+  const [submitting, setSubmitting] = useState(false)
+  const { createIncome } = useIncomeMutations(userId)
+  const { categories, loading: loadingCategories } = useIncomeCategories()
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+
+    if (!formData.date || !formData.amount || !formData.category) {
+      alert('必須項目を入力してください')
+      return
+    }
+
+    const amount = parseFloat(formData.amount)
+    if (isNaN(amount) || amount <= 0) {
+      alert('有効な金額を入力してください')
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      await createIncome({
+        date: new Date(formData.date),
+        amount,
+        category: formData.category,
+        description: formData.description,
+      })
+      setFormData(getInitialIncomeFormData())
+      onSuccess()
+    } catch (error) {
+      console.error('Failed to save income', error)
+      alert('収入の登録に失敗しました')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <form className="expense-form" onSubmit={(e) => void handleSubmit(e)}>
+      <div className="form-row">
+        <div className="form-group">
+          <label htmlFor="income-date">
+            日付 <span className="required">*</span>
+          </label>
+          <input
+            type="date"
+            id="income-date"
+            value={formData.date}
+            onChange={(e) => setFormData({ ...formData, date: e.target.value })}
+            required
+          />
+        </div>
+
+        <div className="form-group">
+          <label htmlFor="income-amount">
+            金額 <span className="required">*</span>
+          </label>
+          <input
+            type="number"
+            id="income-amount"
+            value={formData.amount}
+            onChange={(e) => setFormData({ ...formData, amount: e.target.value })}
+            placeholder="0"
+            min="0"
+            step="1"
+            required
+          />
+        </div>
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="income-category">
+          カテゴリー <span className="required">*</span>
+        </label>
+        {loadingCategories ? (
+          <p className="form-hint">カテゴリーを読み込み中…</p>
+        ) : categories.length === 0 ? (
+          <p className="form-hint">
+            収入カテゴリーがありません。
+            <Link to="/category-tag-management">カテゴリー・タグ管理</Link>
+            から追加してください。
+          </p>
+        ) : (
+          <select
+            id="income-category"
+            value={formData.category}
+            onChange={(e) => setFormData({ ...formData, category: e.target.value })}
+            required
+          >
+            <option value="">選択してください</option>
+            {categories.map((c) => (
+              <option key={c.id} value={c.name}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+        )}
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="income-description">説明</label>
+        <input
+          type="text"
+          id="income-description"
+          value={formData.description}
+          onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+          placeholder="任意"
+        />
+      </div>
+
+      <button
+        type="submit"
+        className="submit-button"
+        disabled={submitting || loadingCategories || categories.length === 0}
+      >
+        {submitting ? '登録中…' : '収入を登録'}
+      </button>
+    </form>
+  )
+}

--- a/src/components/IncomeModal.tsx
+++ b/src/components/IncomeModal.tsx
@@ -1,0 +1,194 @@
+import { useState, useEffect } from 'react'
+import { Link } from 'react-router-dom'
+import { useIncomeMutations } from '../hooks/useIncomeMutations'
+import { useIncomeCategories } from '../hooks/useIncomeCategories'
+import type { Income, UpdateIncomeInput } from '../types'
+import './ExpenseModal.css'
+
+interface IncomeModalProps {
+  income: Income | null
+  userId: string
+  onClose: () => void
+  onUpdate: () => void
+  onDelete: () => void
+}
+
+export const IncomeModal = ({ income, userId, onClose, onUpdate, onDelete }: IncomeModalProps) => {
+  const [formData, setFormData] = useState<UpdateIncomeInput>({})
+  const [dateStr, setDateStr] = useState('')
+  const [amountStr, setAmountStr] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const { updateIncome, deleteIncome } = useIncomeMutations(userId)
+  const { categories, loading: loadingCategories } = useIncomeCategories()
+
+  useEffect(() => {
+    if (income) {
+      const d = income.date.toDate()
+      setDateStr(d.toISOString().split('T')[0])
+      setAmountStr(String(income.amount))
+      setFormData({
+        date: d,
+        amount: income.amount,
+        category: income.category,
+        description: income.description || '',
+      })
+    }
+  }, [income])
+
+  if (!income) return null
+
+  const categoryOptions = [...categories]
+  if (
+    formData.category &&
+    !categories.some((c) => c.name === formData.category)
+  ) {
+    categoryOptions.push({ id: '__current__', name: formData.category })
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!formData.category || !dateStr || !amountStr) {
+      alert('必須項目を入力してください')
+      return
+    }
+    const amount = parseFloat(amountStr)
+    if (isNaN(amount) || amount <= 0) {
+      alert('有効な金額を入力してください')
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      await updateIncome(income.id, {
+        date: new Date(dateStr),
+        amount,
+        category: formData.category,
+        description: formData.description ?? '',
+      })
+      onUpdate()
+      onClose()
+    } catch (error) {
+      console.error('Failed to update income', error)
+      alert('収入の更新に失敗しました')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!confirm('この収入を削除してもよろしいですか？')) return
+    setSubmitting(true)
+    try {
+      await deleteIncome(income.id)
+      onDelete()
+      onClose()
+    } catch (error) {
+      console.error('Failed to delete income', error)
+      alert('収入の削除に失敗しました')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="expense-modal-overlay" onClick={onClose}>
+      <div className="expense-modal-content" onClick={(e) => e.stopPropagation()}>
+        <div className="expense-modal-header">
+          <h2>収入の編集</h2>
+          <button type="button" className="expense-modal-close" onClick={onClose}>
+            ×
+          </button>
+        </div>
+
+        <form className="expense-modal-form" onSubmit={(e) => void handleSubmit(e)}>
+          <div className="form-row">
+            <div className="form-group">
+              <label htmlFor="edit-income-date">
+                日付 <span className="required">*</span>
+              </label>
+              <input
+                type="date"
+                id="edit-income-date"
+                value={dateStr}
+                onChange={(e) => setDateStr(e.target.value)}
+                required
+              />
+            </div>
+            <div className="form-group">
+              <label htmlFor="edit-income-amount">
+                金額 <span className="required">*</span>
+              </label>
+              <input
+                type="number"
+                id="edit-income-amount"
+                value={amountStr}
+                onChange={(e) => setAmountStr(e.target.value)}
+                min="0"
+                step="1"
+                required
+              />
+            </div>
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="edit-income-category">
+              カテゴリー <span className="required">*</span>
+            </label>
+            {loadingCategories ? (
+              <p>カテゴリーを読み込み中…</p>
+            ) : categoryOptions.length === 0 ? (
+              <p>
+                収入カテゴリーがありません。
+                <Link to="/category-tag-management">管理画面</Link>
+                から追加してください。
+              </p>
+            ) : (
+              <select
+                id="edit-income-category"
+                value={formData.category || ''}
+                onChange={(e) => setFormData({ ...formData, category: e.target.value })}
+                required
+              >
+                <option value="">選択してください</option>
+                {categoryOptions.map((c) => (
+                  <option key={c.id} value={c.name}>
+                    {c.name}
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="edit-income-description">説明</label>
+            <input
+              type="text"
+              id="edit-income-description"
+              value={formData.description || ''}
+              onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+            />
+          </div>
+
+          <div className="expense-modal-actions">
+            <button
+              type="button"
+              className="delete-button"
+              disabled={submitting}
+              onClick={() => void handleDelete()}
+            >
+              削除
+            </button>
+            <div className="expense-modal-actions-right">
+              <button type="button" className="cancel-button" onClick={onClose} disabled={submitting}>
+                キャンセル
+              </button>
+              <button type="submit" className="submit-button" disabled={submitting}>
+                {submitting ? '保存中…' : '保存'}
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/components/IncomesTable.test.tsx
+++ b/src/components/IncomesTable.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '../test/testUtils'
+import userEvent from '@testing-library/user-event'
+import { Timestamp } from 'firebase/firestore'
+import { IncomesTable } from './IncomesTable'
+import type { Income } from '../types'
+
+const ts = Timestamp.fromDate(new Date('2026-03-15T12:00:00Z'))
+
+const incomes: Income[] = [
+  {
+    id: 'i1',
+    date: ts,
+    amount: 250000,
+    userId: 'u1',
+    category: '給与',
+    description: '3月分',
+    createdAt: ts,
+    updatedAt: ts,
+  },
+]
+
+describe('IncomesTable', () => {
+  it('shows loading state', () => {
+    render(<IncomesTable incomes={[]} loading onIncomeClick={vi.fn()} />)
+    expect(screen.getByText('読み込み中…')).toBeInTheDocument()
+  })
+
+  it('shows empty message', () => {
+    render(<IncomesTable incomes={[]} loading={false} onIncomeClick={vi.fn()} />)
+    expect(screen.getByText('収入データがありません。')).toBeInTheDocument()
+  })
+
+  it('renders rows and handles click', async () => {
+    const user = userEvent.setup()
+    const onClick = vi.fn()
+    render(<IncomesTable incomes={incomes} loading={false} onIncomeClick={onClick} />)
+
+    expect(screen.getByText('給与')).toBeInTheDocument()
+    expect(screen.getByText('¥250,000')).toBeInTheDocument()
+    expect(screen.getByText('3月分')).toBeInTheDocument()
+
+    await user.click(screen.getByText('給与'))
+    expect(onClick).toHaveBeenCalledWith(incomes[0])
+  })
+})

--- a/src/components/IncomesTable.tsx
+++ b/src/components/IncomesTable.tsx
@@ -1,0 +1,48 @@
+import { formatDate, formatDateTime } from '../utils/dateUtils'
+import type { Income } from '../types'
+import './ExpensesTable.css'
+
+interface IncomesTableProps {
+  incomes: Income[]
+  loading: boolean
+  onIncomeClick: (income: Income) => void
+}
+
+export const IncomesTable = ({ incomes, loading, onIncomeClick }: IncomesTableProps) => {
+  if (loading) {
+    return <p>読み込み中…</p>
+  }
+
+  if (incomes.length === 0) {
+    return <p>収入データがありません。</p>
+  }
+
+  return (
+    <div className="expenses-table-container">
+      <table className="expenses-table">
+        <thead>
+          <tr>
+            <th className="col-date">日付</th>
+            <th className="col-amount">金額</th>
+            <th className="col-category">カテゴリ</th>
+            <th className="col-description">説明</th>
+            <th className="col-created">作成日時</th>
+            <th className="col-updated">更新日時</th>
+          </tr>
+        </thead>
+        <tbody>
+          {incomes.map((income) => (
+            <tr key={income.id} onClick={() => onIncomeClick(income)} className="expense-row">
+              <td className="col-date">{formatDate(income.date)}</td>
+              <td className="col-amount income-amount">¥{income.amount.toLocaleString()}</td>
+              <td className="col-category">{income.category}</td>
+              <td className="col-description">{income.description}</td>
+              <td className="col-created datetime-cell">{formatDateTime(income.createdAt)}</td>
+              <td className="col-updated datetime-cell">{formatDateTime(income.updatedAt)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/src/components/Pagination.test.tsx
+++ b/src/components/Pagination.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '../test/testUtils'
+import userEvent from '@testing-library/user-event'
+import { Pagination } from './Pagination'
+
+describe('Pagination', () => {
+  it('renders nothing when only one page', () => {
+    const { container } = render(
+      <Pagination currentPage={1} totalPages={1} onPageChange={vi.fn()} />
+    )
+    expect(container.querySelector('.pagination')).toBeNull()
+  })
+
+  it('navigates prev/next and page numbers', async () => {
+    const user = userEvent.setup()
+    const onPageChange = vi.fn()
+    render(<Pagination currentPage={2} totalPages={5} onPageChange={onPageChange} />)
+
+    await user.click(screen.getByRole('button', { name: '前へ' }))
+    expect(onPageChange).toHaveBeenCalledWith(1)
+
+    await user.click(screen.getByRole('button', { name: '次へ' }))
+    expect(onPageChange).toHaveBeenCalledWith(3)
+
+    await user.click(screen.getByRole('button', { name: '5' }))
+    expect(onPageChange).toHaveBeenCalledWith(5)
+  })
+
+  it('disables prev on first page and next on last page', () => {
+    const { rerender } = render(
+      <Pagination currentPage={1} totalPages={3} onPageChange={vi.fn()} />
+    )
+    expect(screen.getByRole('button', { name: '前へ' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: '次へ' })).not.toBeDisabled()
+
+    rerender(<Pagination currentPage={3} totalPages={3} onPageChange={vi.fn()} />)
+    expect(screen.getByRole('button', { name: '前へ' })).not.toBeDisabled()
+    expect(screen.getByRole('button', { name: '次へ' })).toBeDisabled()
+  })
+})

--- a/src/constants/defaultIncomeCategories.ts
+++ b/src/constants/defaultIncomeCategories.ts
@@ -1,0 +1,9 @@
+/** 収入登録用の初期カテゴリー候補 */
+export const DEFAULT_INCOME_CATEGORIES = [
+  '給与',
+  'ボーナス',
+  '副業',
+  '投資・配当',
+  '臨時収入',
+  'その他',
+] as const

--- a/src/hooks/useDashboardExpenses.test.tsx
+++ b/src/hooks/useDashboardExpenses.test.tsx
@@ -13,6 +13,9 @@ vi.mock('../services/expenseService', () => ({
   expenseService: {
     getExpensesInMonth: vi.fn(),
     getExpensesByUserId: vi.fn(),
+    getMonthlyTotalForDisplay: vi.fn(),
+    getExpenseCountInMonth: vi.fn(),
+    getExpensesPageForMonth: vi.fn(),
   },
 }))
 
@@ -47,6 +50,13 @@ describe('getCurrentYearMonth', () => {
 describe('useDashboardExpenses', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(expenseService.getMonthlyTotalForDisplay).mockResolvedValue(0)
+    vi.mocked(expenseService.getExpenseCountInMonth).mockResolvedValue(0)
+    vi.mocked(expenseService.getExpensesPageForMonth).mockResolvedValue({
+      expenses: [],
+      lastDoc: null,
+      hasMore: false,
+    })
   })
 
   it('does not fetch when userId is undefined', async () => {
@@ -56,15 +66,21 @@ describe('useDashboardExpenses', () => {
       expect(result.current.loading).toBe(false)
     })
 
-    expect(expenseService.getExpensesInMonth).not.toHaveBeenCalled()
+    expect(expenseService.getExpensesPageForMonth).not.toHaveBeenCalled()
     expect(result.current.expenses).toEqual([])
     expect(result.current.monthExpenseCount).toBe(0)
     expect(result.current.error).toBeNull()
   })
 
-  it('loads month data via getExpensesInMonth and exposes monthExpenseCount', async () => {
+  it('loads totals + first page without getExpensesInMonth', async () => {
     const list = [makeExpense('a', 100), makeExpense('b', 200)]
-    vi.mocked(expenseService.getExpensesInMonth).mockResolvedValue(list)
+    vi.mocked(expenseService.getMonthlyTotalForDisplay).mockResolvedValue(300)
+    vi.mocked(expenseService.getExpenseCountInMonth).mockResolvedValue(2)
+    vi.mocked(expenseService.getExpensesPageForMonth).mockResolvedValue({
+      expenses: list,
+      lastDoc: null,
+      hasMore: false,
+    })
 
     const { result } = renderHook(() => useDashboardExpenses('user-1'))
 
@@ -73,7 +89,15 @@ describe('useDashboardExpenses', () => {
     })
 
     const ym = getCurrentYearMonth()
-    expect(expenseService.getExpensesInMonth).toHaveBeenCalledWith('user-1', ym.year, ym.month)
+    expect(expenseService.getMonthlyTotalForDisplay).toHaveBeenCalledWith('user-1', ym.year, ym.month)
+    expect(expenseService.getExpenseCountInMonth).toHaveBeenCalledWith('user-1', ym.year, ym.month)
+    expect(expenseService.getExpensesPageForMonth).toHaveBeenCalledWith(
+      'user-1',
+      ym.year,
+      ym.month,
+      DASHBOARD_EXPENSE_PAGE_SIZE
+    )
+    expect(expenseService.getExpensesInMonth).not.toHaveBeenCalled()
     expect(result.current.monthExpenseCount).toBe(2)
     expect(result.current.monthlyTotal).toBe(300)
     expect(result.current.expenses).toHaveLength(2)
@@ -81,9 +105,24 @@ describe('useDashboardExpenses', () => {
     expect(expenseService.getExpensesByUserId).not.toHaveBeenCalled()
   })
 
-  it('pages client-side with DASHBOARD_EXPENSE_PAGE_SIZE', async () => {
-    const list = Array.from({ length: 12 }, (_, i) => makeExpense(`id-${i}`, i + 1))
-    vi.mocked(expenseService.getExpensesInMonth).mockResolvedValue(list)
+  it('pages with server fetch when page 2 is requested', async () => {
+    const page1 = Array.from({ length: 10 }, (_, i) => makeExpense(`p1-${i}`, i + 1))
+    const page2 = [makeExpense('p2-0', 11), makeExpense('p2-1', 12)]
+    const fakeLastDoc = { id: 'cursor' } as never
+
+    vi.mocked(expenseService.getMonthlyTotalForDisplay).mockResolvedValue(78)
+    vi.mocked(expenseService.getExpenseCountInMonth).mockResolvedValue(12)
+    vi.mocked(expenseService.getExpensesPageForMonth)
+      .mockResolvedValueOnce({
+        expenses: page1,
+        lastDoc: fakeLastDoc,
+        hasMore: true,
+      })
+      .mockResolvedValueOnce({
+        expenses: page2,
+        lastDoc: null,
+        hasMore: false,
+      })
 
     const { result } = renderHook(() => useDashboardExpenses('user-1'))
 
@@ -95,18 +134,18 @@ describe('useDashboardExpenses', () => {
     expect(result.current.totalPages).toBe(2)
     expect(result.current.currentPage).toBe(1)
 
-    act(() => {
-      void result.current.goToPage(2)
+    await act(async () => {
+      await result.current.goToPage(2)
     })
 
     expect(result.current.expenses).toHaveLength(2)
     expect(result.current.currentPage).toBe(2)
   })
 
-  it('sets error and clears data when getExpensesInMonth fails without calling getExpensesByUserId', async () => {
+  it('sets error and clears data when page load fails without calling getExpensesByUserId', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
     try {
-      vi.mocked(expenseService.getExpensesInMonth).mockRejectedValue(new Error('index required'))
+      vi.mocked(expenseService.getExpensesPageForMonth).mockRejectedValue(new Error('index required'))
 
       const { result } = renderHook(() => useDashboardExpenses('user-1'))
 
@@ -125,8 +164,6 @@ describe('useDashboardExpenses', () => {
   })
 
   it('reloads when setSelectedYearMonth changes target month', async () => {
-    vi.mocked(expenseService.getExpensesInMonth).mockResolvedValue([])
-
     const { result } = renderHook(() => useDashboardExpenses('user-1'))
 
     await waitFor(() => {
@@ -134,25 +171,49 @@ describe('useDashboardExpenses', () => {
     })
 
     const initial = getCurrentYearMonth()
-    expect(expenseService.getExpensesInMonth).toHaveBeenCalledWith('user-1', initial.year, initial.month)
+    expect(expenseService.getExpensesPageForMonth).toHaveBeenCalledWith(
+      'user-1',
+      initial.year,
+      initial.month,
+      DASHBOARD_EXPENSE_PAGE_SIZE
+    )
 
-    vi.mocked(expenseService.getExpensesInMonth).mockClear()
+    vi.mocked(expenseService.getExpensesPageForMonth).mockClear()
 
     act(() => {
       result.current.setSelectedYearMonth(2025, 1)
     })
 
     await waitFor(() => {
-      expect(expenseService.getExpensesInMonth).toHaveBeenCalledWith('user-1', 2025, 1)
+      expect(expenseService.getExpensesPageForMonth).toHaveBeenCalledWith(
+        'user-1',
+        2025,
+        1,
+        DASHBOARD_EXPENSE_PAGE_SIZE
+      )
     })
 
     expect(result.current.selectedYearMonth).toEqual({ year: 2025, month: 1 })
   })
 
   it('refreshAfterMutation reloads data', async () => {
-    vi.mocked(expenseService.getExpensesInMonth)
-      .mockResolvedValueOnce([makeExpense('x', 10)])
-      .mockResolvedValueOnce([makeExpense('x', 10), makeExpense('y', 20)])
+    vi.mocked(expenseService.getExpenseCountInMonth)
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(2)
+    vi.mocked(expenseService.getMonthlyTotalForDisplay)
+      .mockResolvedValueOnce(10)
+      .mockResolvedValueOnce(30)
+    vi.mocked(expenseService.getExpensesPageForMonth)
+      .mockResolvedValueOnce({
+        expenses: [makeExpense('x', 10)],
+        lastDoc: null,
+        hasMore: false,
+      })
+      .mockResolvedValueOnce({
+        expenses: [makeExpense('x', 10), makeExpense('y', 20)],
+        lastDoc: null,
+        hasMore: false,
+      })
 
     const { result } = renderHook(() => useDashboardExpenses('user-1'))
 
@@ -170,6 +231,26 @@ describe('useDashboardExpenses', () => {
       expect(result.current.monthExpenseCount).toBe(2)
     })
 
-    expect(expenseService.getExpensesInMonth).toHaveBeenCalledTimes(2)
+    expect(expenseService.getExpensesPageForMonth).toHaveBeenCalledTimes(2)
+  })
+
+  it('ensureMonthExpensesAll loads full month only when requested', async () => {
+    const full = [makeExpense('a', 1), makeExpense('b', 2)]
+    vi.mocked(expenseService.getExpensesInMonth).mockResolvedValue(full)
+
+    const { result } = renderHook(() => useDashboardExpenses('user-1'))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(expenseService.getExpensesInMonth).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await result.current.ensureMonthExpensesAll()
+    })
+
+    expect(expenseService.getExpensesInMonth).toHaveBeenCalledTimes(1)
+    expect(result.current.monthExpensesAll).toEqual(full)
   })
 })

--- a/src/hooks/useDashboardExpenses.ts
+++ b/src/hooks/useDashboardExpenses.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useLayoutEffect, useRef } from 'react'
+import type { QueryDocumentSnapshot, DocumentData } from 'firebase/firestore'
 import { expenseService } from '../services/expenseService'
 import type { Expense } from '../types'
 
@@ -11,14 +12,10 @@ export function getCurrentYearMonth(): DashboardYearMonth {
   return { year: d.getFullYear(), month: d.getMonth() + 1 }
 }
 
-function sumAmounts(list: Expense[]): number {
-  return list.reduce((s, e) => s + (e.amount || 0), 0)
-}
-
 /**
  * ダッシュボードは選択した暦月の支出を表示。
- * Firestore は月範囲クエリ（userId + date）のみ使用。失敗時も userId 全件取得は行わずエラーにする（読み取り・無料枠対策）。
- * 合計は一覧と同じデータから算出（monthlyTotals ドキュメントに依存しない）。
+ * 合計は monthlyTotals、一覧はサーバーページング、件数は count 集計。
+ * 月全件はカテゴリー／タグ予算突合が必要なときだけ読み取る。
  */
 export const useDashboardExpenses = (userId: string | undefined) => {
   const [yearMonth, setYearMonth] = useState<DashboardYearMonth>(getCurrentYearMonth)
@@ -40,78 +37,161 @@ export const useDashboardExpenses = (userId: string | undefined) => {
   }, [])
 
   const [expenses, setExpenses] = useState<Expense[]>([])
-  /** 選択月分の全件（ページ分割の元） */
   const [monthExpensesAll, setMonthExpensesAll] = useState<Expense[]>([])
+  const [monthExpensesAllLoading, setMonthExpensesAllLoading] = useState(false)
   const [loading, setLoading] = useState(true)
   const [monthlyTotal, setMonthlyTotal] = useState(0)
+  const [monthlyLoading, setMonthlyLoading] = useState(true)
   const [currentPage, setCurrentPage] = useState(1)
   const [totalPages, setTotalPages] = useState(1)
+  const [monthExpenseCount, setMonthExpenseCount] = useState(0)
   const [error, setError] = useState<Error | null>(null)
 
-  const applyClientPage = useCallback((full: Expense[], page: number) => {
-    const start = (page - 1) * DASHBOARD_EXPENSE_PAGE_SIZE
-    setExpenses(full.slice(start, start + DASHBOARD_EXPENSE_PAGE_SIZE))
-    setCurrentPage(page)
-    setTotalPages(Math.max(1, Math.ceil(full.length / DASHBOARD_EXPENSE_PAGE_SIZE)))
+  const pageDataRef = useRef<Map<number, Expense[]>>(new Map())
+  /** page N の末尾ドキュメント（page N+1 の startAfter 用） */
+  const lastDocByPageRef = useRef<Map<number, QueryDocumentSnapshot<DocumentData>>>(new Map())
+  const allLoadedForKeyRef = useRef<string | null>(null)
+
+  const yearMonthKey = `${yearMonth.year}_${yearMonth.month}`
+
+  const resetPaging = useCallback(() => {
+    pageDataRef.current = new Map()
+    lastDocByPageRef.current = new Map()
+    setMonthExpensesAll([])
+    allLoadedForKeyRef.current = null
   }, [])
 
-  const loadDashboardMonthData = useCallback(
+  const loadInitial = useCallback(
     async (opts?: { cancelled?: () => boolean }) => {
       if (!userId) return
       const cancelled = opts?.cancelled ?? (() => false)
       const { year, month } = yearMonth
 
       try {
-        const list = await expenseService.getExpensesInMonth(userId, year, month)
+        const [total, count, pageResult] = await Promise.all([
+          expenseService.getMonthlyTotalForDisplay(userId, year, month),
+          expenseService.getExpenseCountInMonth(userId, year, month),
+          expenseService.getExpensesPageForMonth(
+            userId,
+            year,
+            month,
+            DASHBOARD_EXPENSE_PAGE_SIZE
+          ),
+        ])
         if (cancelled()) return
-        setMonthExpensesAll(list)
-        setMonthlyTotal(sumAmounts(list))
-        applyClientPage(list, 1)
+
+        resetPaging()
+        pageDataRef.current.set(1, pageResult.expenses)
+        if (pageResult.lastDoc) {
+          lastDocByPageRef.current.set(1, pageResult.lastDoc)
+        }
+
+        setMonthlyTotal(total)
+        setMonthExpenseCount(count)
+        setTotalPages(Math.max(1, Math.ceil(count / DASHBOARD_EXPENSE_PAGE_SIZE)))
+        setCurrentPage(1)
+        setExpenses(pageResult.expenses)
         setError(null)
       } catch (err) {
-        console.error('getExpensesInMonth failed (no broad-fetch fallback)', err)
+        console.error('dashboard expense load failed (no broad-fetch fallback)', err)
         if (!cancelled()) {
           setError(err as Error)
-          setMonthExpensesAll([])
+          resetPaging()
           setExpenses([])
           setMonthlyTotal(0)
+          setMonthExpenseCount(0)
           setTotalPages(1)
           setCurrentPage(1)
         }
       }
     },
-    [userId, yearMonth, applyClientPage]
+    [userId, yearMonth, resetPaging]
   )
 
   const goToPage = useCallback(
-    (target: number) => {
-      if (monthExpensesAll.length === 0) {
-        if (target === 1) applyClientPage([], 1)
+    async (target: number) => {
+      if (!userId) return
+      const maxPage = Math.max(1, Math.ceil(monthExpenseCount / DASHBOARD_EXPENSE_PAGE_SIZE))
+      const page = Math.min(Math.max(1, target), maxPage)
+
+      if (pageDataRef.current.has(page)) {
+        setExpenses(pageDataRef.current.get(page)!)
+        setCurrentPage(page)
         return
       }
-      const maxPage = Math.max(1, Math.ceil(monthExpensesAll.length / DASHBOARD_EXPENSE_PAGE_SIZE))
-      const page = Math.min(Math.max(1, target), maxPage)
-      applyClientPage(monthExpensesAll, page)
+
+      const { year, month } = yearMonth
+      let walk = 1
+      while (walk < page) {
+        if (!pageDataRef.current.has(walk + 1)) {
+          const startAfterDoc = lastDocByPageRef.current.get(walk)
+          if (!startAfterDoc) break
+          const result = await expenseService.getExpensesPageForMonth(
+            userId,
+            year,
+            month,
+            DASHBOARD_EXPENSE_PAGE_SIZE,
+            startAfterDoc
+          )
+          pageDataRef.current.set(walk + 1, result.expenses)
+          if (result.lastDoc) {
+            lastDocByPageRef.current.set(walk + 1, result.lastDoc)
+          }
+          if (!result.hasMore) break
+        }
+        walk += 1
+      }
+
+      if (pageDataRef.current.has(page)) {
+        setExpenses(pageDataRef.current.get(page)!)
+        setCurrentPage(page)
+      }
     },
-    [monthExpensesAll, applyClientPage]
+    [userId, yearMonth, monthExpenseCount]
   )
+
+  /** カテゴリー／タグ予算の実績突合用。必要なときだけ月全件を読む */
+  const ensureMonthExpensesAll = useCallback(async () => {
+    if (!userId) return []
+    if (allLoadedForKeyRef.current === yearMonthKey) {
+      return monthExpensesAll
+    }
+
+    setMonthExpensesAllLoading(true)
+    try {
+      const list = await expenseService.getExpensesInMonth(
+        userId,
+        yearMonth.year,
+        yearMonth.month
+      )
+      allLoadedForKeyRef.current = yearMonthKey
+      setMonthExpensesAll(list)
+      return list
+    } finally {
+      setMonthExpensesAllLoading(false)
+    }
+  }, [userId, yearMonth, yearMonthKey, monthExpensesAll])
 
   const refreshAfterMutation = useCallback(async () => {
     if (!userId) return
     setLoading(true)
+    setMonthlyLoading(true)
     try {
-      await loadDashboardMonthData()
+      await loadInitial()
     } finally {
       setLoading(false)
+      setMonthlyLoading(false)
     }
-  }, [userId, loadDashboardMonthData])
+  }, [userId, loadInitial])
 
   useEffect(() => {
     if (!userId) {
-      setMonthExpensesAll([])
+      resetPaging()
       setExpenses([])
       setMonthlyTotal(0)
+      setMonthExpenseCount(0)
       setLoading(false)
+      setMonthlyLoading(false)
       setCurrentPage(1)
       setTotalPages(1)
       setError(null)
@@ -122,30 +202,35 @@ export const useDashboardExpenses = (userId: string | undefined) => {
     const isCancelled = () => cancelled
 
     setLoading(true)
+    setMonthlyLoading(true)
     setError(null)
 
-    void loadDashboardMonthData({ cancelled: isCancelled }).finally(() => {
-      if (!isCancelled()) setLoading(false)
+    void loadInitial({ cancelled: isCancelled }).finally(() => {
+      if (!isCancelled()) {
+        setLoading(false)
+        setMonthlyLoading(false)
+      }
     })
 
     return () => {
       cancelled = true
     }
-  }, [userId, yearMonth, loadDashboardMonthData])
+  }, [userId, yearMonth, loadInitial, resetPaging])
 
   return {
     expenses,
+    monthExpensesAll,
+    monthExpensesAllLoading,
+    ensureMonthExpensesAll,
     loading,
     monthlyTotal,
-    /** 合計カードも一覧と同じロードに揃える */
-    monthlyLoading: loading,
+    monthlyLoading,
     currentPage,
     totalPages,
     goToPage,
     refreshAfterMutation,
     error,
-    /** 選択月に取得した支出の件数（ページング前の全件） */
-    monthExpenseCount: monthExpensesAll.length,
+    monthExpenseCount,
     selectedYearMonth: yearMonth,
     setSelectedYearMonth,
   }

--- a/src/hooks/useDashboardIncomes.test.tsx
+++ b/src/hooks/useDashboardIncomes.test.tsx
@@ -1,0 +1,129 @@
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Timestamp } from 'firebase/firestore'
+import {
+  useDashboardIncomes,
+  DASHBOARD_INCOME_PAGE_SIZE,
+} from './useDashboardIncomes'
+import { incomeService } from '../services/incomeService'
+import type { Income } from '../types'
+
+vi.mock('../services/incomeService', () => ({
+  incomeService: {
+    getMonthlyIncomeTotalForDisplay: vi.fn(),
+    getIncomesInMonth: vi.fn(),
+  },
+}))
+
+function makeIncome(id: string, amount: number): Income {
+  const ts = Timestamp.fromDate(new Date('2026-03-15T12:00:00Z'))
+  return {
+    id,
+    date: ts,
+    amount,
+    userId: 'user-1',
+    category: '給与',
+    description: '',
+    createdAt: ts,
+    updatedAt: ts,
+  }
+}
+
+const ym = { year: 2026, month: 3 }
+
+describe('useDashboardIncomes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(incomeService.getMonthlyIncomeTotalForDisplay).mockResolvedValue(0)
+    vi.mocked(incomeService.getIncomesInMonth).mockResolvedValue([])
+  })
+
+  it('loads total only when list is disabled', async () => {
+    vi.mocked(incomeService.getMonthlyIncomeTotalForDisplay).mockResolvedValue(50000)
+
+    const { result } = renderHook(() => useDashboardIncomes('user-1', ym, false))
+
+    await waitFor(() => {
+      expect(result.current.monthlyLoading).toBe(false)
+    })
+
+    expect(incomeService.getMonthlyIncomeTotalForDisplay).toHaveBeenCalledWith(
+      'user-1',
+      2026,
+      3
+    )
+    expect(incomeService.getIncomesInMonth).not.toHaveBeenCalled()
+    expect(result.current.monthlyTotal).toBe(50000)
+    expect(result.current.incomes).toEqual([])
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('loads list when enabled', async () => {
+    const list = [makeIncome('a', 100), makeIncome('b', 200)]
+    vi.mocked(incomeService.getMonthlyIncomeTotalForDisplay).mockResolvedValue(300)
+    vi.mocked(incomeService.getIncomesInMonth).mockResolvedValue(list)
+
+    const { result } = renderHook(() => useDashboardIncomes('user-1', ym, true))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+      expect(result.current.monthlyLoading).toBe(false)
+    })
+
+    expect(incomeService.getIncomesInMonth).toHaveBeenCalledWith('user-1', 2026, 3)
+    expect(result.current.monthIncomeCount).toBe(2)
+    expect(result.current.incomes).toHaveLength(2)
+    expect(result.current.monthlyTotal).toBe(300)
+  })
+
+  it('pages client-side when list has more than page size', async () => {
+    const list = Array.from({ length: 12 }, (_, i) => makeIncome(`id-${i}`, i + 1))
+    vi.mocked(incomeService.getIncomesInMonth).mockResolvedValue(list)
+    vi.mocked(incomeService.getMonthlyIncomeTotalForDisplay).mockResolvedValue(78)
+
+    const { result } = renderHook(() => useDashboardIncomes('user-1', ym, true))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.incomes).toHaveLength(DASHBOARD_INCOME_PAGE_SIZE)
+    expect(result.current.totalPages).toBe(2)
+
+    act(() => {
+      result.current.goToPage(2)
+    })
+
+    expect(result.current.incomes).toHaveLength(2)
+    expect(result.current.currentPage).toBe(2)
+  })
+
+  it('does not fetch when userId is undefined', async () => {
+    const { result } = renderHook(() => useDashboardIncomes(undefined, ym, true))
+
+    await waitFor(() => {
+      expect(result.current.monthlyLoading).toBe(false)
+    })
+
+    expect(incomeService.getMonthlyIncomeTotalForDisplay).not.toHaveBeenCalled()
+    expect(incomeService.getIncomesInMonth).not.toHaveBeenCalled()
+  })
+
+  it('sets error when list fetch fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      vi.mocked(incomeService.getIncomesInMonth).mockRejectedValue(new Error('index required'))
+
+      const { result } = renderHook(() => useDashboardIncomes('user-1', ym, true))
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false)
+      })
+
+      expect(result.current.error?.message).toBe('index required')
+      expect(result.current.incomes).toEqual([])
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
+})

--- a/src/hooks/useDashboardIncomes.ts
+++ b/src/hooks/useDashboardIncomes.ts
@@ -1,0 +1,159 @@
+import { useState, useEffect, useCallback } from 'react'
+import { incomeService } from '../services/incomeService'
+import type { DashboardYearMonth } from './useDashboardExpenses'
+import type { Income } from '../types'
+
+export const DASHBOARD_INCOME_PAGE_SIZE = 10
+
+/**
+ * ダッシュボード用収入。
+ * - 合計は常に monthlyIncomeTotals（1 read）
+ * - 一覧は enabled のときだけ月全件（トグルで開いたとき）
+ */
+export const useDashboardIncomes = (
+  userId: string | undefined,
+  yearMonth: DashboardYearMonth,
+  enabled = true
+) => {
+  const [incomes, setIncomes] = useState<Income[]>([])
+  const [monthIncomesAll, setMonthIncomesAll] = useState<Income[]>([])
+  const [listLoading, setListLoading] = useState(false)
+  const [monthlyTotal, setMonthlyTotal] = useState(0)
+  const [monthlyLoading, setMonthlyLoading] = useState(true)
+  const [currentPage, setCurrentPage] = useState(1)
+  const [totalPages, setTotalPages] = useState(1)
+  const [error, setError] = useState<Error | null>(null)
+
+  const applyClientPage = useCallback((full: Income[], page: number) => {
+    const start = (page - 1) * DASHBOARD_INCOME_PAGE_SIZE
+    setIncomes(full.slice(start, start + DASHBOARD_INCOME_PAGE_SIZE))
+    setCurrentPage(page)
+    setTotalPages(Math.max(1, Math.ceil(full.length / DASHBOARD_INCOME_PAGE_SIZE)))
+  }, [])
+
+  const loadTotal = useCallback(
+    async (opts?: { cancelled?: () => boolean }) => {
+      if (!userId) return
+      const cancelled = opts?.cancelled ?? (() => false)
+      const { year, month } = yearMonth
+      try {
+        const total = await incomeService.getMonthlyIncomeTotalForDisplay(userId, year, month)
+        if (cancelled()) return
+        setMonthlyTotal(total)
+      } catch (err) {
+        console.error('getMonthlyIncomeTotalForDisplay failed', err)
+        if (!cancelled()) setMonthlyTotal(0)
+      }
+    },
+    [userId, yearMonth]
+  )
+
+  const loadList = useCallback(
+    async (opts?: { cancelled?: () => boolean }) => {
+      if (!userId || !enabled) return
+      const cancelled = opts?.cancelled ?? (() => false)
+      const { year, month } = yearMonth
+
+      try {
+        const list = await incomeService.getIncomesInMonth(userId, year, month)
+        if (cancelled()) return
+        setMonthIncomesAll(list)
+        applyClientPage(list, 1)
+        setError(null)
+      } catch (err) {
+        console.error('getIncomesInMonth failed', err)
+        if (!cancelled()) {
+          setError(err as Error)
+          setMonthIncomesAll([])
+          setIncomes([])
+          setTotalPages(1)
+          setCurrentPage(1)
+        }
+      }
+    },
+    [userId, yearMonth, enabled, applyClientPage]
+  )
+
+  const goToPage = useCallback(
+    (target: number) => {
+      if (monthIncomesAll.length === 0) {
+        if (target === 1) applyClientPage([], 1)
+        return
+      }
+      const maxPage = Math.max(1, Math.ceil(monthIncomesAll.length / DASHBOARD_INCOME_PAGE_SIZE))
+      const page = Math.min(Math.max(1, target), maxPage)
+      applyClientPage(monthIncomesAll, page)
+    },
+    [monthIncomesAll, applyClientPage]
+  )
+
+  const refreshAfterMutation = useCallback(async () => {
+    if (!userId) return
+    setMonthlyLoading(true)
+    if (enabled) setListLoading(true)
+    try {
+      await loadTotal()
+      if (enabled) await loadList()
+      else {
+        // 合計だけ更新済み。一覧は閉じていれば次に開いたときに再取得
+        setMonthIncomesAll([])
+        setIncomes([])
+      }
+    } finally {
+      setMonthlyLoading(false)
+      setListLoading(false)
+    }
+  }, [userId, enabled, loadTotal, loadList])
+
+  useEffect(() => {
+    if (!userId) {
+      setMonthlyTotal(0)
+      setMonthlyLoading(false)
+      return
+    }
+    let cancelled = false
+    setMonthlyLoading(true)
+    void loadTotal({ cancelled: () => cancelled }).finally(() => {
+      if (!cancelled) setMonthlyLoading(false)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [userId, yearMonth, loadTotal])
+
+  useEffect(() => {
+    if (!userId || !enabled) {
+      setMonthIncomesAll([])
+      setIncomes([])
+      setListLoading(false)
+      setCurrentPage(1)
+      setTotalPages(1)
+      setError(null)
+      return
+    }
+
+    let cancelled = false
+    setListLoading(true)
+    setError(null)
+    void loadList({ cancelled: () => cancelled }).finally(() => {
+      if (!cancelled) setListLoading(false)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [userId, yearMonth, enabled, loadList])
+
+  return {
+    incomes,
+    monthIncomesAll,
+    loading: listLoading,
+    monthlyTotal,
+    monthlyLoading,
+    currentPage,
+    totalPages,
+    goToPage,
+    refreshAfterMutation,
+    error,
+    monthIncomeCount: monthIncomesAll.length,
+  }
+}

--- a/src/hooks/useExpenses.test.tsx
+++ b/src/hooks/useExpenses.test.tsx
@@ -1,0 +1,89 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Timestamp } from 'firebase/firestore'
+import { useExpenses } from './useExpenses'
+import { expenseService } from '../services/expenseService'
+import type { Expense } from '../types'
+
+vi.mock('../services/expenseService', () => ({
+  expenseService: {
+    getExpensesInMonth: vi.fn(),
+    getExpensesByUserId: vi.fn(),
+    getExpensesForRecentMonths: vi.fn(),
+  },
+}))
+
+vi.mock('./useExpenseMutations', () => ({
+  useExpenseMutations: () => ({
+    createExpense: vi.fn(),
+    updateExpense: vi.fn(),
+    deleteExpense: vi.fn(),
+  }),
+}))
+
+function makeExpense(id: string): Expense {
+  const ts = Timestamp.now()
+  return {
+    id,
+    date: ts,
+    amount: 100,
+    userId: 'u1',
+    bigCategory: '食費',
+    tags: '',
+    paymentMethod: '',
+    description: '',
+    createdAt: ts,
+    updatedAt: ts,
+  }
+}
+
+describe('useExpenses', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('loads month data when year and month are set', async () => {
+    vi.mocked(expenseService.getExpensesInMonth).mockResolvedValue([makeExpense('a')])
+
+    const { result } = renderHook(() =>
+      useExpenses('u1', { year: 2026, month: 3 })
+    )
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(expenseService.getExpensesInMonth).toHaveBeenCalledWith('u1', 2026, 3)
+    expect(expenseService.getExpensesByUserId).not.toHaveBeenCalled()
+    expect(result.current.expenses).toHaveLength(1)
+  })
+
+  it('loads recent months when recentMonths is set', async () => {
+    vi.mocked(expenseService.getExpensesForRecentMonths).mockResolvedValue([
+      makeExpense('r1'),
+      makeExpense('r2'),
+    ])
+
+    const { result } = renderHook(() => useExpenses('u1', { recentMonths: 24 }))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(expenseService.getExpensesForRecentMonths).toHaveBeenCalledWith('u1', 24)
+    expect(expenseService.getExpensesByUserId).not.toHaveBeenCalled()
+    expect(result.current.expenses).toHaveLength(2)
+  })
+
+  it('falls back to all expenses when no scope options', async () => {
+    vi.mocked(expenseService.getExpensesByUserId).mockResolvedValue([makeExpense('all')])
+
+    const { result } = renderHook(() => useExpenses('u1'))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(expenseService.getExpensesByUserId).toHaveBeenCalledWith('u1')
+  })
+})

--- a/src/hooks/useExpenses.ts
+++ b/src/hooks/useExpenses.ts
@@ -3,15 +3,30 @@ import { expenseService } from '../services/expenseService'
 import { useExpenseMutations } from './useExpenseMutations'
 import type { Expense, CreateExpenseInput, UpdateExpenseInput } from '../types'
 
-export const useExpenses = (userId: string | undefined) => {
+export type UseExpensesOptions = {
+  /** 指定時はその月だけ取得（読取抑制） */
+  year?: number | null
+  month?: number | null
+  /**
+   * year/month 未指定時: 全期間の代わりに直近 N か月のみ（サマリー用）。
+   * 未指定なら従来どおり全件。
+   */
+  recentMonths?: number
+}
+
+export const useExpenses = (userId: string | undefined, options?: UseExpensesOptions) => {
   const { createExpense: createExpenseDoc, updateExpense: updateExpenseDoc, deleteExpense: deleteExpenseDoc } =
     useExpenseMutations(userId)
   const [expenses, setExpenses] = useState<Expense[]>([])
   const [loading, setLoading] = useState<boolean>(true)
   const [error, setError] = useState<Error | null>(null)
 
+  const year = options?.year ?? null
+  const month = options?.month ?? null
+  const recentMonths = options?.recentMonths
+
   const loadExpensesFromServer = useCallback(
-    async (options: { withLoadingSpinner: boolean }) => {
+    async (loadOpts: { withLoadingSpinner: boolean }) => {
       if (!userId) {
         setExpenses([])
         setError(null)
@@ -19,24 +34,31 @@ export const useExpenses = (userId: string | undefined) => {
         return
       }
 
-      if (options.withLoadingSpinner) {
+      if (loadOpts.withLoadingSpinner) {
         setLoading(true)
       }
       try {
         setError(null)
-        const data = await expenseService.getExpensesByUserId(userId)
+        let data: Expense[]
+        if (year != null && month != null) {
+          data = await expenseService.getExpensesInMonth(userId, year, month)
+        } else if (recentMonths != null && recentMonths > 0) {
+          data = await expenseService.getExpensesForRecentMonths(userId, recentMonths)
+        } else {
+          data = await expenseService.getExpensesByUserId(userId)
+        }
         setExpenses(data)
       } catch (e) {
         console.error('Failed to load expenses', e)
         setError(e as Error)
         setExpenses([])
       } finally {
-        if (options.withLoadingSpinner) {
+        if (loadOpts.withLoadingSpinner) {
           setLoading(false)
         }
       }
     },
-    [userId]
+    [userId, year, month, recentMonths]
   )
 
   useEffect(() => {
@@ -48,7 +70,6 @@ export const useExpenses = (userId: string | undefined) => {
     await loadExpensesFromServer({ withLoadingSpinner: false })
   }
 
-  // 支出を作成
   const createExpense = async (input: CreateExpenseInput): Promise<string | null> => {
     if (!userId) {
       throw new Error('User ID is required')
@@ -65,7 +86,6 @@ export const useExpenses = (userId: string | undefined) => {
     }
   }
 
-  // 支出を更新
   const updateExpense = async (expenseId: string, input: UpdateExpenseInput): Promise<void> => {
     try {
       await updateExpenseDoc(expenseId, input)
@@ -77,7 +97,6 @@ export const useExpenses = (userId: string | undefined) => {
     }
   }
 
-  // 支出を削除
   const deleteExpense = async (expenseId: string): Promise<void> => {
     try {
       await deleteExpenseDoc(expenseId)
@@ -99,4 +118,3 @@ export const useExpenses = (userId: string | undefined) => {
     deleteExpense,
   }
 }
-

--- a/src/hooks/useIncomeCategories.test.tsx
+++ b/src/hooks/useIncomeCategories.test.tsx
@@ -1,0 +1,81 @@
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useIncomeCategories } from './useIncomeCategories'
+import { incomeCategoryService } from '../services/incomeCategoryService'
+import type { Category } from '../types'
+
+vi.mock('../services/incomeCategoryService', () => ({
+  incomeCategoryService: {
+    getAllCategories: vi.fn(),
+  },
+}))
+
+const cats: Category[] = [
+  {
+    id: '1',
+    name: '給与',
+    order: 0,
+  },
+]
+
+describe('useIncomeCategories', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(incomeCategoryService.getAllCategories).mockResolvedValue(cats)
+  })
+
+  it('does not fetch when enabled is false', async () => {
+    const { result } = renderHook(() => useIncomeCategories({ enabled: false }))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(incomeCategoryService.getAllCategories).not.toHaveBeenCalled()
+    expect(result.current.categories).toEqual([])
+  })
+
+  it('fetches when enabled', async () => {
+    const { result } = renderHook(() => useIncomeCategories({ enabled: true }))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(incomeCategoryService.getAllCategories).toHaveBeenCalled()
+    expect(result.current.categories).toEqual(cats)
+  })
+
+  it('fetches by default when options omitted', async () => {
+    const { result } = renderHook(() => useIncomeCategories())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(incomeCategoryService.getAllCategories).toHaveBeenCalled()
+  })
+
+  it('refreshCategories reloads data', async () => {
+    const { result } = renderHook(() => useIncomeCategories({ enabled: true }))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    vi.mocked(incomeCategoryService.getAllCategories).mockResolvedValue([
+      ...cats,
+      {
+        id: '2',
+        name: 'ボーナス',
+        order: 1,
+      },
+    ])
+
+    await act(async () => {
+      await result.current.refreshCategories()
+    })
+
+    expect(result.current.categories).toHaveLength(2)
+  })
+})

--- a/src/hooks/useIncomeCategories.ts
+++ b/src/hooks/useIncomeCategories.ts
@@ -1,0 +1,59 @@
+import { useState, useEffect, useCallback } from 'react'
+import { incomeCategoryService } from '../services/incomeCategoryService'
+import type { Category } from '../types'
+
+export type UseIncomeCategoriesOptions = {
+  /** false のときは取得しない（管理画面の折りたたみ用） */
+  enabled?: boolean
+}
+
+export const useIncomeCategories = (options?: UseIncomeCategoriesOptions) => {
+  const enabled = options?.enabled !== false
+  const [categories, setCategories] = useState<Category[]>([])
+  const [loading, setLoading] = useState(enabled)
+  const [error, setError] = useState<Error | null>(null)
+
+  const refreshCategories = useCallback(async () => {
+    if (!enabled) return
+    try {
+      const data = await incomeCategoryService.getAllCategories()
+      setCategories(data)
+      setError(null)
+    } catch (e) {
+      console.error('Failed to refresh income categories', e)
+      setError(e as Error)
+    }
+  }, [enabled])
+
+  useEffect(() => {
+    if (!enabled) {
+      setCategories([])
+      setLoading(false)
+      setError(null)
+      return
+    }
+
+    let cancelled = false
+    ;(async () => {
+      try {
+        setLoading(true)
+        setError(null)
+        const data = await incomeCategoryService.getAllCategories()
+        if (!cancelled) setCategories(data)
+      } catch (e) {
+        console.error('Failed to load income categories', e)
+        if (!cancelled) {
+          setError(e as Error)
+          setCategories([])
+        }
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [enabled])
+
+  return { categories, loading, error, refreshCategories }
+}

--- a/src/hooks/useIncomeMutations.ts
+++ b/src/hooks/useIncomeMutations.ts
@@ -1,0 +1,29 @@
+import { useCallback } from 'react'
+import { incomeService } from '../services/incomeService'
+import type { CreateIncomeInput, UpdateIncomeInput } from '../types'
+
+export const useIncomeMutations = (userId: string | undefined) => {
+  const createIncome = useCallback(
+    async (input: CreateIncomeInput): Promise<string> => {
+      if (!userId) {
+        throw new Error('User ID is required')
+      }
+      return incomeService.createIncome(userId, input)
+    },
+    [userId]
+  )
+
+  const updateIncome = useCallback(async (incomeId: string, input: UpdateIncomeInput): Promise<void> => {
+    await incomeService.updateIncome(incomeId, input)
+  }, [])
+
+  const deleteIncome = useCallback(async (incomeId: string): Promise<void> => {
+    await incomeService.deleteIncome(incomeId)
+  }, [])
+
+  return {
+    createIncome,
+    updateIncome,
+    deleteIncome,
+  }
+}

--- a/src/hooks/useMonthBudgetCarryover.test.tsx
+++ b/src/hooks/useMonthBudgetCarryover.test.tsx
@@ -1,0 +1,101 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useMonthBudgetCarryover } from './useMonthBudgetCarryover'
+import { listTotalBudgetLimitsForYear } from '../services/budgetService'
+import { expenseService } from '../services/expenseService'
+
+vi.mock('../services/budgetService', () => ({
+  listTotalBudgetLimitsForYear: vi.fn(),
+}))
+
+vi.mock('../services/expenseService', () => ({
+  expenseService: {
+    getSpentByMonthForYear: vi.fn(),
+  },
+}))
+
+function emptyBudgetMap(): Record<number, number | null> {
+  const m: Record<number, number | null> = {}
+  for (let i = 1; i <= 12; i++) m[i] = null
+  return m
+}
+
+function emptySpentMap(): Record<number, number> {
+  const m: Record<number, number> = {}
+  for (let i = 1; i <= 12; i++) m[i] = 0
+  return m
+}
+
+describe('useMonthBudgetCarryover', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does nothing when userId is undefined', async () => {
+    const { result } = renderHook(() => useMonthBudgetCarryover(undefined, 2026, 3))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(listTotalBudgetLimitsForYear).not.toHaveBeenCalled()
+    expect(result.current.carryover).toBeNull()
+  })
+
+  it('computes carryIn from previous year December carryOut', async () => {
+    const prevBudgets = emptyBudgetMap()
+    prevBudgets[12] = 100_000
+    const prevSpent = emptySpentMap()
+    prevSpent[12] = 40_000
+
+    const curBudgets = emptyBudgetMap()
+    curBudgets[1] = 100_000
+    curBudgets[2] = 100_000
+    curBudgets[3] = 100_000
+    const curSpent = emptySpentMap()
+    curSpent[1] = 0
+    curSpent[2] = 0
+    curSpent[3] = 10_000
+
+    vi.mocked(listTotalBudgetLimitsForYear)
+      .mockResolvedValueOnce(prevBudgets)
+      .mockResolvedValueOnce(curBudgets)
+    vi.mocked(expenseService.getSpentByMonthForYear)
+      .mockResolvedValueOnce(prevSpent)
+      .mockResolvedValueOnce(curSpent)
+
+    const { result } = renderHook(() => useMonthBudgetCarryover('user-1', 2026, 3))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(listTotalBudgetLimitsForYear).toHaveBeenCalledWith('user-1', 2025)
+    expect(listTotalBudgetLimitsForYear).toHaveBeenCalledWith('user-1', 2026)
+    expect(expenseService.getSpentByMonthForYear).toHaveBeenCalledWith('user-1', 2025, 12)
+    expect(expenseService.getSpentByMonthForYear).toHaveBeenCalledWith('user-1', 2026, 3)
+
+    // prev Dec remaining 60_000 → Jan carryIn; Jan/Feb unused accumulate
+    expect(result.current.carryover).toMatchObject({
+      year: 2026,
+      month: 3,
+      budgetLimit: 100_000,
+      spent: 10_000,
+      carryIn: 260_000,
+    })
+    expect(result.current.error).toBeNull()
+  })
+
+  it('sets error when fetch fails', async () => {
+    vi.mocked(listTotalBudgetLimitsForYear).mockRejectedValue(new Error('network'))
+
+    const { result } = renderHook(() => useMonthBudgetCarryover('user-1', 2026, 1))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.error?.message).toBe('network')
+    expect(result.current.carryover).toBeNull()
+  })
+})

--- a/src/hooks/useMonthBudgetCarryover.ts
+++ b/src/hooks/useMonthBudgetCarryover.ts
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react'
+import { listTotalBudgetLimitsForYear } from '../services/budgetService'
+import { expenseService } from '../services/expenseService'
+import {
+  buildYearMonthBudgetSpent,
+  computeCarryoverChain,
+  type MonthCarryover,
+} from '../utils/budgetCarryover'
+
+/**
+ * 指定月の全体予算について、前月までの繰越を加味した有効予算を算出する。
+ * - 全体予算のみ取得（カテゴリー／タグ別は読まない）
+ * - 当年の実績は選択月まで
+ * - 前年は年初からのチェーンに必要な12か月
+ */
+export function useMonthBudgetCarryover(
+  userId: string | undefined,
+  year: number,
+  month: number
+): {
+  carryover: MonthCarryover | null
+  loading: boolean
+  error: Error | null
+} {
+  const [carryover, setCarryover] = useState<MonthCarryover | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<Error | null>(null)
+
+  useEffect(() => {
+    if (!userId) {
+      setCarryover(null)
+      setLoading(false)
+      setError(null)
+      return
+    }
+
+    let cancelled = false
+    ;(async () => {
+      setLoading(true)
+      setError(null)
+      try {
+        const [prevBudgetMap, curBudgetMap, prevSpent, curSpent] = await Promise.all([
+          listTotalBudgetLimitsForYear(userId, year - 1),
+          listTotalBudgetLimitsForYear(userId, year),
+          expenseService.getSpentByMonthForYear(userId, year - 1, 12),
+          expenseService.getSpentByMonthForYear(userId, year, month),
+        ])
+        if (cancelled) return
+
+        const prevChain = computeCarryoverChain(
+          buildYearMonthBudgetSpent(year - 1, prevBudgetMap, prevSpent),
+          0
+        )
+        const initialCarryIn = prevChain[11]?.carryOut ?? 0
+        const curChain = computeCarryoverChain(
+          buildYearMonthBudgetSpent(year, curBudgetMap, curSpent),
+          initialCarryIn
+        )
+        const row = curChain.find((r) => r.month === month) ?? null
+        setCarryover(row)
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e : new Error(String(e)))
+          setCarryover(null)
+        }
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [userId, year, month])
+
+  return { carryover, loading, error }
+}

--- a/src/hooks/useMonthScopedBudgets.test.tsx
+++ b/src/hooks/useMonthScopedBudgets.test.tsx
@@ -1,0 +1,88 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Timestamp } from 'firebase/firestore'
+import { useMonthScopedBudgets } from './useMonthScopedBudgets'
+import { listBudgetsForMonth } from '../services/budgetService'
+import type { MonthlyBudget } from '../types'
+
+vi.mock('../services/budgetService', () => ({
+  listBudgetsForMonth: vi.fn(),
+}))
+
+const ts = Timestamp.now()
+
+function budget(partial: Partial<MonthlyBudget> & Pick<MonthlyBudget, 'id'>): MonthlyBudget {
+  return {
+    userId: 'u1',
+    year: 2026,
+    month: 4,
+    amountLimit: 1000,
+    categoryId: null,
+    categoryName: null,
+    tagId: null,
+    tagName: null,
+    updatedAt: ts,
+    ...partial,
+  }
+}
+
+describe('useMonthScopedBudgets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('clears when userId is undefined', async () => {
+    const { result } = renderHook(() => useMonthScopedBudgets(undefined, 2026, 4))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(listBudgetsForMonth).not.toHaveBeenCalled()
+    expect(result.current.categoryBudgets).toEqual([])
+    expect(result.current.tagBudgets).toEqual([])
+  })
+
+  it('splits category and tag budgets and excludes totals', async () => {
+    vi.mocked(listBudgetsForMonth).mockResolvedValue([
+      budget({ id: 'total', amountLimit: 50000 }),
+      budget({
+        id: 'cat',
+        categoryId: 'c1',
+        categoryName: '食費',
+        amountLimit: 10000,
+      }),
+      budget({
+        id: 'tag',
+        tagId: 't1',
+        tagName: 'ランチ',
+        amountLimit: 3000,
+      }),
+    ])
+
+    const { result } = renderHook(() => useMonthScopedBudgets('user-1', 2026, 4))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(listBudgetsForMonth).toHaveBeenCalledWith('user-1', 2026, 4)
+    expect(result.current.categoryBudgets).toHaveLength(1)
+    expect(result.current.categoryBudgets[0].categoryName).toBe('食費')
+    expect(result.current.tagBudgets).toHaveLength(1)
+    expect(result.current.tagBudgets[0].tagName).toBe('ランチ')
+  })
+
+  it('sets error on failure', async () => {
+    vi.mocked(listBudgetsForMonth).mockRejectedValue(new Error('denied'))
+
+    const { result } = renderHook(() => useMonthScopedBudgets('user-1', 2026, 4))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.error?.message).toBe('denied')
+    expect(result.current.categoryBudgets).toEqual([])
+  })
+})

--- a/src/hooks/useMonthScopedBudgets.ts
+++ b/src/hooks/useMonthScopedBudgets.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react'
+import { listBudgetsForMonth } from '../services/budgetService'
+import type { MonthlyBudget } from '../types'
+
+/**
+ * 指定月のカテゴリー別・タグ別予算のみ取得（全体予算は含めない）。
+ */
+export function useMonthScopedBudgets(
+  userId: string | undefined,
+  year: number,
+  month: number
+): {
+  categoryBudgets: MonthlyBudget[]
+  tagBudgets: MonthlyBudget[]
+  loading: boolean
+  error: Error | null
+} {
+  const [categoryBudgets, setCategoryBudgets] = useState<MonthlyBudget[]>([])
+  const [tagBudgets, setTagBudgets] = useState<MonthlyBudget[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<Error | null>(null)
+
+  useEffect(() => {
+    if (!userId) {
+      setCategoryBudgets([])
+      setTagBudgets([])
+      setLoading(false)
+      setError(null)
+      return
+    }
+
+    let cancelled = false
+    ;(async () => {
+      setLoading(true)
+      setError(null)
+      try {
+        const list = await listBudgetsForMonth(userId, year, month)
+        if (cancelled) return
+        setCategoryBudgets(list.filter((b) => b.categoryId && !b.tagId))
+        setTagBudgets(list.filter((b) => Boolean(b.tagId)))
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e : new Error(String(e)))
+          setCategoryBudgets([])
+          setTagBudgets([])
+        }
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [userId, year, month])
+
+  return { categoryBudgets, tagBudgets, loading, error }
+}

--- a/src/hooks/useTotalMonthBudget.test.tsx
+++ b/src/hooks/useTotalMonthBudget.test.tsx
@@ -1,0 +1,65 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Timestamp } from 'firebase/firestore'
+import { useTotalMonthBudget } from './useTotalMonthBudget'
+import { getMonthlyTotalBudget } from '../services/budgetService'
+import type { MonthlyBudget } from '../types'
+
+vi.mock('../services/budgetService', () => ({
+  getMonthlyTotalBudget: vi.fn(),
+}))
+
+describe('useTotalMonthBudget', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns null without fetching when userId is undefined', async () => {
+    const { result } = renderHook(() => useTotalMonthBudget(undefined, 2026, 3))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(getMonthlyTotalBudget).not.toHaveBeenCalled()
+    expect(result.current.totalBudget).toBeNull()
+  })
+
+  it('loads total budget document', async () => {
+    const budget: MonthlyBudget = {
+      id: '2026_03',
+      userId: 'u1',
+      year: 2026,
+      month: 3,
+      amountLimit: 120000,
+      categoryId: null,
+      categoryName: null,
+      tagId: null,
+      tagName: null,
+      updatedAt: Timestamp.now(),
+    }
+    vi.mocked(getMonthlyTotalBudget).mockResolvedValue(budget)
+
+    const { result } = renderHook(() => useTotalMonthBudget('u1', 2026, 3))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(getMonthlyTotalBudget).toHaveBeenCalledWith('u1', 2026, 3)
+    expect(result.current.totalBudget?.amountLimit).toBe(120000)
+  })
+
+  it('sets error when get fails', async () => {
+    vi.mocked(getMonthlyTotalBudget).mockRejectedValue(new Error('offline'))
+
+    const { result } = renderHook(() => useTotalMonthBudget('u1', 2026, 3))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.error?.message).toBe('offline')
+    expect(result.current.totalBudget).toBeNull()
+  })
+})

--- a/src/hooks/useTotalMonthBudget.ts
+++ b/src/hooks/useTotalMonthBudget.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react'
+import { getMonthlyTotalBudget } from '../services/budgetService'
+import type { MonthlyBudget } from '../types'
+
+/**
+ * 月次「全体」予算を one-shot 取得（ダッシュボード用。realtime は使わない）。
+ */
+export function useTotalMonthBudget(
+  userId: string | undefined,
+  year: number,
+  month: number
+): { totalBudget: MonthlyBudget | null; loading: boolean; error: Error | null } {
+  const [totalBudget, setTotalBudget] = useState<MonthlyBudget | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<Error | null>(null)
+
+  useEffect(() => {
+    if (!userId) {
+      setTotalBudget(null)
+      setLoading(false)
+      setError(null)
+      return
+    }
+
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    void getMonthlyTotalBudget(userId, year, month)
+      .then((b) => {
+        if (!cancelled) setTotalBudget(b)
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err : new Error(String(err)))
+          setTotalBudget(null)
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [userId, year, month])
+
+  return { totalBudget, loading, error }
+}

--- a/src/pages/Budget/Budget.css
+++ b/src/pages/Budget/Budget.css
@@ -1,0 +1,365 @@
+.budget-page {
+  min-height: 100vh;
+  background-color: #f8fafc;
+  padding: 2rem 1.5rem 3rem;
+  box-sizing: border-box;
+}
+
+.budget-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  max-width: 56rem;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.budget-header h1 {
+  margin: 0;
+  font-size: 1.75rem;
+  color: #0f172a;
+}
+
+.budget-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.budget-link-dashboard {
+  font-weight: 600;
+  color: #2563eb;
+  text-decoration: none;
+}
+
+.budget-link-dashboard:hover {
+  text-decoration: underline;
+}
+
+.budget-main {
+  max-width: 56rem;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.budget-card {
+  background: #fff;
+  border-radius: 1rem;
+  padding: 1.25rem 1.5rem;
+  box-shadow: 0 4px 20px rgba(15, 23, 42, 0.06);
+}
+
+.budget-card h2 {
+  margin: 0 0 1rem;
+  font-size: 1.1rem;
+  color: #0f172a;
+}
+
+.budget-ym-picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+
+.budget-ym-picker label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #475569;
+}
+
+.budget-select {
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid #e2e8f0;
+  font-family: inherit;
+  font-size: 0.95rem;
+  min-width: 6rem;
+}
+
+.budget-select--grow {
+  flex: 1;
+  min-width: 8rem;
+}
+
+.budget-hint {
+  margin: 1rem 0 0;
+  font-size: 0.85rem;
+  color: #64748b;
+  line-height: 1.5;
+}
+
+.budget-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.budget-label {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: #334155;
+}
+
+.budget-input {
+  padding: 0.6rem 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid #e2e8f0;
+  font-size: 1rem;
+  max-width: 16rem;
+}
+
+.budget-input--narrow {
+  max-width: 10rem;
+}
+
+.budget-field-hint {
+  margin: 0.75rem 0 0;
+  font-size: 0.8rem;
+  color: #64748b;
+}
+
+.budget-section-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.budget-section-head h2 {
+  margin: 0;
+}
+
+.budget-year-sum {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #334155;
+}
+
+.budget-bulk {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 0.75rem 1rem;
+  margin-bottom: 1.25rem;
+  padding-bottom: 1.25rem;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.budget-bulk-field {
+  margin: 0;
+}
+
+.budget-bulk-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.budget-year-table-wrap {
+  overflow-x: auto;
+}
+
+.budget-year-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.budget-year-table th,
+.budget-year-table td {
+  padding: 0.55rem 0.5rem;
+  text-align: left;
+  border-bottom: 1px solid #e2e8f0;
+  vertical-align: middle;
+}
+
+.budget-year-table thead th {
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: #64748b;
+  letter-spacing: 0.02em;
+}
+
+.budget-year-table tbody th {
+  font-weight: 600;
+  color: #0f172a;
+  width: 3rem;
+  white-space: nowrap;
+}
+
+.budget-num {
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  color: #334155;
+  font-size: 0.9rem;
+}
+
+.budget-num--over {
+  color: #b91c1c;
+  font-weight: 600;
+}
+
+.budget-input--table {
+  max-width: 8.5rem;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.budget-year-row--active {
+  background: #eff6ff;
+}
+
+.budget-detail-toggle {
+  padding: 0.35rem 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid #cbd5e1;
+  background: #fff;
+  color: #334155;
+  font-weight: 600;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.budget-detail-toggle:hover {
+  background: #f1f5f9;
+}
+
+.budget-detail-block {
+  margin-bottom: 1.25rem;
+}
+
+.budget-detail-block:last-child {
+  margin-bottom: 0;
+}
+
+.budget-subheading {
+  margin: 0;
+  font-size: 1rem;
+  color: #0f172a;
+}
+
+.budget-add-row {
+  padding: 0.4rem 0.85rem;
+  border-radius: 0.5rem;
+  border: 1px solid #3b82f6;
+  background: #fff;
+  color: #2563eb;
+  font-weight: 600;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.budget-add-row:hover {
+  background: #eff6ff;
+}
+
+.budget-danger-btn {
+  padding: 0.4rem 0.85rem;
+  border-radius: 0.5rem;
+  border: 1px solid #dc2626;
+  background: #fff;
+  color: #b91c1c;
+  font-weight: 600;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.budget-danger-btn:hover:not(:disabled) {
+  background: #fef2f2;
+}
+
+.budget-danger-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.budget-row-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.budget-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.budget-remove-row {
+  padding: 0.35rem 0.65rem;
+  font-size: 0.8rem;
+  border: none;
+  border-radius: 0.375rem;
+  background: #fee2e2;
+  color: #b91c1c;
+  cursor: pointer;
+}
+
+.budget-remove-row:hover {
+  background: #fecaca;
+}
+
+.budget-save-bar {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.budget-save {
+  padding: 0.65rem 1.5rem;
+  border: none;
+  border-radius: 0.5rem;
+  background: #3b82f6;
+  color: #fff;
+  font-weight: 700;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.budget-save:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.budget-save:not(:disabled):hover {
+  background: #2563eb;
+}
+
+.budget-error {
+  margin: 0;
+  color: #b91c1c;
+  font-size: 0.9rem;
+}
+
+.budget-success {
+  margin: 0;
+  color: #047857;
+  font-size: 0.9rem;
+}
+
+.budget-loading {
+  color: #64748b;
+}
+
+@media (max-width: 560px) {
+  .budget-input--table {
+    max-width: 9rem;
+  }
+}

--- a/src/pages/Budget/Budget.tsx
+++ b/src/pages/Budget/Budget.tsx
@@ -1,0 +1,772 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
+import { useAuth } from '../../context/AuthContext'
+import { getCurrentYearMonth } from '../../hooks/useDashboardExpenses'
+import { categoryService } from '../../services/categoryService'
+import { tagService } from '../../services/tagService'
+import {
+  listBudgetsForYear,
+  listBudgetsForMonth,
+  listTotalBudgetLimitsForYear,
+  setBudget,
+  deleteBudget,
+} from '../../services/budgetService'
+import { expenseService } from '../../services/expenseService'
+import { previousCalendarMonth } from '../../utils/budgetMonth'
+import {
+  buildYearMonthBudgetSpent,
+  computeCarryoverChain,
+  formatCarryoverYen,
+  type MonthCarryover,
+} from '../../utils/budgetCarryover'
+import type { Category, Tag } from '../../types'
+import './Budget.css'
+
+function parseYear(searchParams: URLSearchParams): number {
+  const cur = getCurrentYearMonth()
+  const y = Number(searchParams.get('year'))
+  return Number.isFinite(y) && y >= 2000 && y <= 2100 ? y : cur.year
+}
+
+/** URL の month は詳細パネルの初期選択に使う（任意） */
+function parseOptionalMonth(searchParams: URLSearchParams): number | null {
+  const m = Number(searchParams.get('month'))
+  return Number.isFinite(m) && m >= 1 && m <= 12 ? m : null
+}
+
+/** 空欄は null。不正な入力は 'invalid' */
+function parseOptionalAmount(s: string): number | null | 'invalid' {
+  const t = s.trim()
+  if (t === '') return null
+  const n = Number(t)
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) return 'invalid'
+  return n
+}
+
+function emptyMonthTotals(): Record<number, string> {
+  const o: Record<number, string> = {}
+  for (let m = 1; m <= 12; m++) o[m] = ''
+  return o
+}
+
+const Budget = () => {
+  const { user } = useAuth()
+  const navigate = useNavigate()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const year = useMemo(() => parseYear(searchParams), [searchParams])
+  const initialDetailMonth = useMemo(() => parseOptionalMonth(searchParams), [searchParams])
+
+  const [categories, setCategories] = useState<Category[]>([])
+  const [tags, setTags] = useState<Tag[]>([])
+  const [monthTotals, setMonthTotals] = useState<Record<number, string>>(emptyMonthTotals)
+  /** 読み込み時点で DB に存在した全体予算の月（空欄保存時の削除判定用） */
+  const [savedTotalMonths, setSavedTotalMonths] = useState<Set<number>>(new Set())
+  const [detailMonth, setDetailMonth] = useState<number | null>(initialDetailMonth)
+  const [categoryRows, setCategoryRows] = useState<Array<{ categoryId: string; amount: string }>>([])
+  const [tagRows, setTagRows] = useState<Array<{ tagId: string; amount: string }>>([])
+  const [loading, setLoading] = useState(true)
+  const [detailLoading, setDetailLoading] = useState(false)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const [saveOk, setSaveOk] = useState(false)
+  const [bulkAmount, setBulkAmount] = useState('')
+  const [spentByMonth, setSpentByMonth] = useState<Record<number, number>>({})
+  const [initialCarryIn, setInitialCarryIn] = useState(0)
+
+  const loadYearTotals = useCallback(async () => {
+    if (!user?.uid) return
+    setLoading(true)
+    setLoadError(null)
+    setSaveOk(false)
+    try {
+      const [totalLimits, spent, prevBudgetMap, prevSpent] = await Promise.all([
+        listTotalBudgetLimitsForYear(user.uid, year),
+        expenseService.getSpentByMonthForYear(user.uid, year, 12),
+        listTotalBudgetLimitsForYear(user.uid, year - 1),
+        expenseService.getSpentByMonthForYear(user.uid, year - 1, 12),
+      ])
+      const savedMonths = new Set<number>()
+      for (let m = 1; m <= 12; m++) {
+        if (totalLimits[m] != null) savedMonths.add(m)
+      }
+      setSavedTotalMonths(savedMonths)
+      setSpentByMonth(spent)
+
+      const prevChain = computeCarryoverChain(
+        buildYearMonthBudgetSpent(year - 1, prevBudgetMap, prevSpent),
+        0
+      )
+      setInitialCarryIn(prevChain[11]?.carryOut ?? 0)
+
+      const next = emptyMonthTotals()
+      for (let m = 1; m <= 12; m++) {
+        const limit = totalLimits[m]
+        if (limit != null) next[m] = String(limit)
+      }
+      setMonthTotals(next)
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : '読み込みに失敗しました')
+    } finally {
+      setLoading(false)
+    }
+  }, [user?.uid, year])
+
+  const loadDetailForMonth = useCallback(
+    async (month: number) => {
+      if (!user?.uid) return
+      setDetailLoading(true)
+      setLoadError(null)
+      try {
+        const prev = previousCalendarMonth(year, month)
+        const [cur, prevList] = await Promise.all([
+          listBudgetsForMonth(user.uid, year, month),
+          listBudgetsForMonth(user.uid, prev.year, prev.month),
+        ])
+
+        const curCats = cur.filter((b) => b.categoryId && !b.tagId)
+        const prevCats = prevList.filter((b) => b.categoryId && !b.tagId)
+        const catIdSet = new Set<string>([
+          ...curCats.map((b) => b.categoryId!),
+          ...prevCats.map((b) => b.categoryId!),
+        ])
+        setCategoryRows(
+          Array.from(catIdSet).map((id) => {
+            const c = curCats.find((x) => x.categoryId === id)
+            const p = prevCats.find((x) => x.categoryId === id)
+            const amt = c?.amountLimit ?? p?.amountLimit
+            return { categoryId: id, amount: amt != null ? String(amt) : '' }
+          })
+        )
+
+        const curT = cur.filter((b) => b.tagId)
+        const prevT = prevList.filter((b) => b.tagId)
+        const tagIdSet = new Set<string>([...curT.map((b) => b.tagId!), ...prevT.map((b) => b.tagId!)])
+        setTagRows(
+          Array.from(tagIdSet).map((id) => {
+            const c = curT.find((x) => x.tagId === id)
+            const p = prevT.find((x) => x.tagId === id)
+            const amt = c?.amountLimit ?? p?.amountLimit
+            return { tagId: id, amount: amt != null ? String(amt) : '' }
+          })
+        )
+      } catch (e) {
+        setLoadError(e instanceof Error ? e.message : '詳細の読み込みに失敗しました')
+      } finally {
+        setDetailLoading(false)
+      }
+    },
+    [user?.uid, year]
+  )
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      try {
+        const [cats, tgs] = await Promise.all([
+          categoryService.getAllCategories(),
+          tagService.getAllTags(),
+        ])
+        if (!cancelled) {
+          setCategories(cats)
+          setTags(tgs)
+        }
+      } catch {
+        if (!cancelled) setLoadError('マスタの取得に失敗しました')
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadYearTotals()
+  }, [loadYearTotals])
+
+  useEffect(() => {
+    setDetailMonth(initialDetailMonth)
+  }, [year, initialDetailMonth])
+
+  useEffect(() => {
+    if (detailMonth == null) {
+      setCategoryRows([])
+      setTagRows([])
+      return
+    }
+    void loadDetailForMonth(detailMonth)
+  }, [detailMonth, loadDetailForMonth])
+
+  const setYear = (y: number) => {
+    const next = new URLSearchParams(searchParams)
+    next.set('year', String(y))
+    if (detailMonth != null) {
+      next.set('month', String(detailMonth))
+    } else {
+      next.delete('month')
+    }
+    setSearchParams(next, { replace: true })
+  }
+
+  const openDetail = (month: number) => {
+    setDetailMonth(month)
+    const next = new URLSearchParams(searchParams)
+    next.set('year', String(year))
+    next.set('month', String(month))
+    setSearchParams(next, { replace: true })
+  }
+
+  const closeDetail = () => {
+    setDetailMonth(null)
+    const next = new URLSearchParams(searchParams)
+    next.set('year', String(year))
+    next.delete('month')
+    setSearchParams(next, { replace: true })
+  }
+
+  const categoryName = (id: string) => categories.find((c) => c.id === id)?.name ?? id
+  const tagName = (id: string) => tags.find((t) => t.id === id)?.name ?? id
+
+  const yearTotalSum = useMemo(() => {
+    let sum = 0
+    let count = 0
+    for (let m = 1; m <= 12; m++) {
+      const n = parseOptionalAmount(monthTotals[m] ?? '')
+      if (typeof n === 'number') {
+        sum += n
+        count += 1
+      }
+    }
+    return { sum, count }
+  }, [monthTotals])
+
+  const carryoverByMonth = useMemo(() => {
+    const budgetByMonth: Record<number, number | null> = {}
+    for (let m = 1; m <= 12; m++) {
+      const parsed = parseOptionalAmount(monthTotals[m] ?? '')
+      budgetByMonth[m] = typeof parsed === 'number' ? parsed : null
+    }
+    const chain = computeCarryoverChain(
+      buildYearMonthBudgetSpent(year, budgetByMonth, spentByMonth),
+      initialCarryIn
+    )
+    const map: Record<number, MonthCarryover> = {}
+    for (const row of chain) {
+      map[row.month] = row
+    }
+    return map
+  }, [year, monthTotals, spentByMonth, initialCarryIn])
+
+  const applyBulkToEmpty = () => {
+    const n = parseOptionalAmount(bulkAmount)
+    if (n === 'invalid' || n === null) {
+      setSaveError('一括入力は0以上の整数を指定してください')
+      return
+    }
+    setSaveError(null)
+    setMonthTotals((prev) => {
+      const next = { ...prev }
+      for (let m = 1; m <= 12; m++) {
+        if (next[m].trim() === '') next[m] = String(n)
+      }
+      return next
+    })
+  }
+
+  const applyBulkToAll = () => {
+    const n = parseOptionalAmount(bulkAmount)
+    if (n === 'invalid' || n === null) {
+      setSaveError('一括入力は0以上の整数を指定してください')
+      return
+    }
+    setSaveError(null)
+    const next = emptyMonthTotals()
+    for (let m = 1; m <= 12; m++) next[m] = String(n)
+    setMonthTotals(next)
+  }
+
+  /**
+   * 一括入力額を「今月以降」の月に適用（表示中の年のみ）。
+   * - 表示年 === 今年 → 今月〜12月
+   * - 表示年 > 今年 → 1〜12月（その年の全月）
+   * - 表示年 < 今年 → 適用不可
+   */
+  const applyBulkFromThisMonthOnward = () => {
+    const n = parseOptionalAmount(bulkAmount)
+    if (n === 'invalid' || n === null) {
+      setSaveError('一括入力は0以上の整数を指定してください')
+      return
+    }
+    const cur = getCurrentYearMonth()
+    if (year < cur.year) {
+      setSaveError('過去の年には「今月以降に適用」できません')
+      return
+    }
+    const fromMonth = year === cur.year ? cur.month : 1
+    setSaveError(null)
+    setMonthTotals((prev) => {
+      const next = { ...prev }
+      for (let m = fromMonth; m <= 12; m++) {
+        next[m] = String(n)
+      }
+      return next
+    })
+  }
+
+  /** 表示中の年の予算（全体・カテゴリー・タグ）をすべて削除 */
+  const deleteAllYearBudgets = async () => {
+    if (!user?.uid) return
+    const ok = window.confirm(
+      `${year}年の予算（全体・カテゴリー別・タグ別）をすべて削除します。よろしいですか？`
+    )
+    if (!ok) return
+
+    setSaving(true)
+    setSaveError(null)
+    setSaveOk(false)
+    try {
+      const list = await listBudgetsForYear(user.uid, year)
+      for (const b of list) {
+        if (b.tagId) {
+          await deleteBudget(user.uid, b.year, b.month, { tagId: b.tagId })
+        } else if (b.categoryId) {
+          await deleteBudget(user.uid, b.year, b.month, { categoryId: b.categoryId })
+        } else {
+          await deleteBudget(user.uid, b.year, b.month)
+        }
+      }
+      closeDetail()
+      setSaveOk(true)
+      await loadYearTotals()
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : '全予算の削除に失敗しました')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleSave = async () => {
+    if (!user?.uid) return
+    setSaving(true)
+    setSaveError(null)
+    setSaveOk(false)
+    try {
+      for (let m = 1; m <= 12; m++) {
+        const parsed = parseOptionalAmount(monthTotals[m] ?? '')
+        if (parsed === 'invalid') {
+          setSaveError(`${m}月の全体予算は空欄か、0以上の整数を入力してください`)
+          setSaving(false)
+          return
+        }
+        if (parsed === null) {
+          if (savedTotalMonths.has(m)) {
+            await deleteBudget(user.uid, year, m)
+          }
+        } else {
+          await setBudget(user.uid, year, m, parsed)
+        }
+      }
+
+      if (detailMonth != null) {
+        const curList = await listBudgetsForMonth(user.uid, year, detailMonth)
+        const curCatIds = new Set(curList.filter((b) => b.categoryId && !b.tagId).map((b) => b.categoryId!))
+        const desiredCatIds = new Set(categoryRows.filter((r) => r.categoryId).map((r) => r.categoryId))
+        for (const id of curCatIds) {
+          if (!desiredCatIds.has(id)) {
+            await deleteBudget(user.uid, year, detailMonth, { categoryId: id })
+          }
+        }
+        for (const row of categoryRows) {
+          if (!row.categoryId) continue
+          const n = parseOptionalAmount(row.amount)
+          if (n === 'invalid') {
+            setSaveError('カテゴリー別予算は0以上の整数で入力してください')
+            setSaving(false)
+            return
+          }
+          if (n === null) {
+            if (curCatIds.has(row.categoryId)) {
+              await deleteBudget(user.uid, year, detailMonth, { categoryId: row.categoryId })
+            }
+            continue
+          }
+          await setBudget(user.uid, year, detailMonth, n, {
+            categoryId: row.categoryId,
+            categoryName: categoryName(row.categoryId),
+          })
+        }
+
+        const curTagIds = new Set(curList.filter((b) => b.tagId).map((b) => b.tagId!))
+        const desiredTagIds = new Set(tagRows.filter((r) => r.tagId).map((r) => r.tagId))
+        for (const id of curTagIds) {
+          if (!desiredTagIds.has(id)) {
+            await deleteBudget(user.uid, year, detailMonth, { tagId: id })
+          }
+        }
+        for (const row of tagRows) {
+          if (!row.tagId) continue
+          const n = parseOptionalAmount(row.amount)
+          if (n === 'invalid') {
+            setSaveError('タグ別予算は0以上の整数で入力してください')
+            setSaving(false)
+            return
+          }
+          if (n === null) {
+            if (curTagIds.has(row.tagId)) {
+              await deleteBudget(user.uid, year, detailMonth, { tagId: row.tagId })
+            }
+            continue
+          }
+          await setBudget(user.uid, year, detailMonth, n, {
+            tagId: row.tagId,
+            tagName: tagName(row.tagId),
+          })
+        }
+      }
+
+      navigate('/dashboard', { replace: true })
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : '保存に失敗しました')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const yearOptions = useMemo(() => {
+    const ys = new Set<number>()
+    for (let y = year - 3; y <= year + 1; y++) ys.add(y)
+    ys.add(getCurrentYearMonth().year)
+    return Array.from(ys).sort((a, b) => a - b)
+  }, [year])
+
+  return (
+    <div className="budget-page">
+      <header className="budget-header">
+        <h1>予算</h1>
+        <div className="budget-header-actions">
+          <Link to="/dashboard" className="budget-link-dashboard">
+            ダッシュボードへ
+          </Link>
+        </div>
+      </header>
+
+      <main className="budget-main">
+        <section className="budget-card">
+          <h2>対象の年</h2>
+          <div className="budget-ym-picker" role="group" aria-label="予算を設定する年">
+            <label>
+              年
+              <select
+                value={year}
+                onChange={(e) => setYear(Number(e.target.value))}
+                className="budget-select"
+              >
+                {yearOptions.map((y) => (
+                  <option key={y} value={y}>
+                    {y}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+          <p className="budget-hint">
+            {year}年の1〜12月の全体予算を一覧で確認・編集できます。繰越は「予算＋前月繰入−実績」で、超過や予算未設定月の支出はマイナスとして翌月へ引き継ぎます。
+          </p>
+        </section>
+
+        {loadError && (
+          <p className="budget-error" role="alert">
+            {loadError}
+          </p>
+        )}
+
+        {loading ? (
+          <p className="budget-loading">読み込み中…</p>
+        ) : (
+          <>
+            <section className="budget-card">
+              <div className="budget-section-head">
+                <h2>{year}年の月次予算（全体）</h2>
+                <p className="budget-year-sum" aria-live="polite">
+                  入力 {yearTotalSum.count} か月 · 合計 ¥{yearTotalSum.sum.toLocaleString()}
+                </p>
+              </div>
+
+              <div className="budget-bulk">
+                <label className="budget-field budget-bulk-field">
+                  <span className="budget-label">一括入力（円）</span>
+                  <input
+                    type="number"
+                    min={0}
+                    step={1}
+                    inputMode="numeric"
+                    className="budget-input budget-input--narrow"
+                    value={bulkAmount}
+                    onChange={(e) => setBulkAmount(e.target.value)}
+                    placeholder="例: 150000"
+                  />
+                </label>
+                <div className="budget-bulk-actions">
+                  <button type="button" className="budget-add-row" onClick={applyBulkToEmpty}>
+                    空の月に適用
+                  </button>
+                  <button type="button" className="budget-add-row" onClick={applyBulkToAll}>
+                    全年月に適用
+                  </button>
+                  <button
+                    type="button"
+                    className="budget-add-row"
+                    onClick={applyBulkFromThisMonthOnward}
+                  >
+                    今月以降に適用
+                  </button>
+                  <button
+                    type="button"
+                    className="budget-danger-btn"
+                    disabled={saving}
+                    onClick={() => void deleteAllYearBudgets()}
+                  >
+                    全予算削除
+                  </button>
+                </div>
+              </div>
+
+              <div className="budget-year-table-wrap">
+                <table className="budget-year-table">
+                  <thead>
+                    <tr>
+                      <th scope="col">月</th>
+                      <th scope="col">全体予算</th>
+                      <th scope="col">実績</th>
+                      <th scope="col">繰入</th>
+                      <th scope="col">有効予算</th>
+                      <th scope="col">繰越</th>
+                      <th scope="col">詳細</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {Array.from({ length: 12 }, (_, i) => i + 1).map((m) => {
+                      const co = carryoverByMonth[m]
+                      return (
+                        <tr
+                          key={m}
+                          className={detailMonth === m ? 'budget-year-row--active' : undefined}
+                        >
+                          <th scope="row">{m}月</th>
+                          <td>
+                            <input
+                              type="number"
+                              min={0}
+                              step={1}
+                              inputMode="numeric"
+                              className="budget-input budget-input--table"
+                              value={monthTotals[m] ?? ''}
+                              onChange={(e) => {
+                                const v = e.target.value
+                                setMonthTotals((prev) => ({ ...prev, [m]: v }))
+                              }}
+                              aria-label={`${m}月の全体予算`}
+                              placeholder="未設定"
+                            />
+                          </td>
+                          <td className="budget-num">
+                            ¥{(co?.spent ?? spentByMonth[m] ?? 0).toLocaleString()}
+                          </td>
+                          <td
+                            className={`budget-num${co != null && co.carryIn < 0 ? ' budget-num--over' : ''}`}
+                          >
+                            {co ? formatCarryoverYen(co.carryIn) : '—'}
+                          </td>
+                          <td
+                            className={`budget-num${co != null && co.available < 0 ? ' budget-num--over' : ''}`}
+                          >
+                            {co ? formatCarryoverYen(co.available) : '—'}
+                          </td>
+                          <td
+                            className={`budget-num${co != null && co.carryOut < 0 ? ' budget-num--over' : ''}`}
+                          >
+                            {co ? formatCarryoverYen(co.carryOut) : '—'}
+                          </td>
+                          <td>
+                            <button
+                              type="button"
+                              className="budget-detail-toggle"
+                              onClick={() => (detailMonth === m ? closeDetail() : openDetail(m))}
+                              aria-expanded={detailMonth === m}
+                            >
+                              {detailMonth === m ? '閉じる' : '詳細'}
+                            </button>
+                          </td>
+                        </tr>
+                      )
+                    })}
+                  </tbody>
+                </table>
+              </div>
+              <p className="budget-field-hint">
+                空欄にして保存すると、その月の全体予算を削除します。繰越列は入力中の予算と実績から都度再計算されます（保存前でも反映）。
+              </p>
+            </section>
+
+            {detailMonth != null && (
+              <section className="budget-card" aria-labelledby="budget-detail-heading">
+                <div className="budget-section-head">
+                  <h2 id="budget-detail-heading">
+                    {year}年{detailMonth}月のカテゴリー・タグ別
+                  </h2>
+                  <button type="button" className="budget-add-row" onClick={closeDetail}>
+                    閉じる
+                  </button>
+                </div>
+
+                {detailLoading ? (
+                  <p className="budget-loading">詳細を読み込み中…</p>
+                ) : (
+                  <>
+                    <div className="budget-detail-block">
+                      <div className="budget-section-head">
+                        <h3 className="budget-subheading">カテゴリー別</h3>
+                        <button
+                          type="button"
+                          className="budget-add-row"
+                          onClick={() =>
+                            setCategoryRows((rows) => [...rows, { categoryId: '', amount: '' }])
+                          }
+                        >
+                          行を追加
+                        </button>
+                      </div>
+                      <ul className="budget-row-list">
+                        {categoryRows.map((row, index) => (
+                          <li key={`${row.categoryId || 'new'}-${index}`} className="budget-row">
+                            <select
+                              className="budget-select budget-select--grow"
+                              value={row.categoryId}
+                              onChange={(e) => {
+                                const v = e.target.value
+                                setCategoryRows((rows) =>
+                                  rows.map((r, i) => (i === index ? { ...r, categoryId: v } : r))
+                                )
+                              }}
+                            >
+                              <option value="">カテゴリーを選択</option>
+                              {categories.map((c) => (
+                                <option key={c.id} value={c.id}>
+                                  {c.name}
+                                </option>
+                              ))}
+                            </select>
+                            <input
+                              type="number"
+                              min={0}
+                              step={1}
+                              className="budget-input budget-input--narrow"
+                              placeholder="円"
+                              value={row.amount}
+                              onChange={(e) => {
+                                const v = e.target.value
+                                setCategoryRows((rows) =>
+                                  rows.map((r, i) => (i === index ? { ...r, amount: v } : r))
+                                )
+                              }}
+                            />
+                            <button
+                              type="button"
+                              className="budget-remove-row"
+                              onClick={() =>
+                                setCategoryRows((rows) => rows.filter((_, i) => i !== index))
+                              }
+                              aria-label="この行を削除"
+                            >
+                              削除
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+
+                    <div className="budget-detail-block">
+                      <div className="budget-section-head">
+                        <h3 className="budget-subheading">タグ別</h3>
+                        <button
+                          type="button"
+                          className="budget-add-row"
+                          onClick={() => setTagRows((rows) => [...rows, { tagId: '', amount: '' }])}
+                        >
+                          行を追加
+                        </button>
+                      </div>
+                      <ul className="budget-row-list">
+                        {tagRows.map((row, index) => (
+                          <li key={`${row.tagId || 'new'}-${index}`} className="budget-row">
+                            <select
+                              className="budget-select budget-select--grow"
+                              value={row.tagId}
+                              onChange={(e) => {
+                                const v = e.target.value
+                                setTagRows((rows) =>
+                                  rows.map((r, i) => (i === index ? { ...r, tagId: v } : r))
+                                )
+                              }}
+                            >
+                              <option value="">タグを選択</option>
+                              {tags.map((t) => (
+                                <option key={t.id} value={t.id}>
+                                  {t.name}
+                                </option>
+                              ))}
+                            </select>
+                            <input
+                              type="number"
+                              min={0}
+                              step={1}
+                              className="budget-input budget-input--narrow"
+                              placeholder="円"
+                              value={row.amount}
+                              onChange={(e) => {
+                                const v = e.target.value
+                                setTagRows((rows) =>
+                                  rows.map((r, i) => (i === index ? { ...r, amount: v } : r))
+                                )
+                              }}
+                            />
+                            <button
+                              type="button"
+                              className="budget-remove-row"
+                              onClick={() => setTagRows((rows) => rows.filter((_, i) => i !== index))}
+                              aria-label="この行を削除"
+                            >
+                              削除
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  </>
+                )}
+              </section>
+            )}
+
+            <div className="budget-save-bar">
+              {saveError && (
+                <p className="budget-error" role="alert">
+                  {saveError}
+                </p>
+              )}
+              {saveOk && (
+                <p className="budget-success" role="status">
+                  保存しました。
+                </p>
+              )}
+              <button type="button" className="budget-save" disabled={saving} onClick={() => void handleSave()}>
+                {saving ? '保存中…' : '保存'}
+              </button>
+            </div>
+          </>
+        )}
+      </main>
+    </div>
+  )
+}
+
+export default Budget

--- a/src/pages/CategoryTagManagement/CategoryTagManagement.css
+++ b/src/pages/CategoryTagManagement/CategoryTagManagement.css
@@ -92,6 +92,50 @@
   justify-content: space-between;
   align-items: center;
   margin-bottom: 1rem;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.section-header-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.income-category-toggle-card {
+  padding-top: 0.85rem;
+  padding-bottom: 0.85rem;
+}
+
+.income-section-toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.35rem 0.15rem;
+  margin-bottom: 0;
+  border: none;
+  background: transparent;
+  color: #334155;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.income-section-toggle:hover {
+  color: #0f172a;
+}
+
+.income-section-toggle[aria-expanded='true'] {
+  margin-bottom: 1rem;
+}
+
+.income-section-toggle-icon {
+  font-size: 0.75rem;
+  opacity: 0.7;
 }
 
 .toggle-form-button {

--- a/src/pages/CategoryTagManagement/CategoryTagManagement.test.tsx
+++ b/src/pages/CategoryTagManagement/CategoryTagManagement.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from '../../test/testUtils'
 import CategoryTagManagement from './CategoryTagManagement'
 import { useAuth } from '../../context/AuthContext'
 import { useCategories } from '../../hooks/useCategories'
+import { useIncomeCategories } from '../../hooks/useIncomeCategories'
 import { useTags } from '../../hooks/useTags'
 import { useUserName } from '../../hooks/useUserName'
 import type { User } from 'firebase/auth'
@@ -10,6 +11,7 @@ import type { User } from 'firebase/auth'
 // モック
 vi.mock('../../context/AuthContext')
 vi.mock('../../hooks/useCategories')
+vi.mock('../../hooks/useIncomeCategories')
 vi.mock('../../hooks/useTags')
 vi.mock('../../hooks/useUserName')
 vi.mock('../../components/CategoryForm', () => ({
@@ -17,6 +19,9 @@ vi.mock('../../components/CategoryForm', () => ({
 }))
 vi.mock('../../components/TagForm', () => ({
   TagForm: () => <div data-testid="tag-form">Tag Form</div>,
+}))
+vi.mock('../../components/IncomeCategoryModal', () => ({
+  IncomeCategoryModal: () => null,
 }))
 
 const mockUser = {
@@ -45,6 +50,12 @@ const mockUser = {
 describe('CategoryTagManagement', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(useIncomeCategories).mockReturnValue({
+      categories: [],
+      loading: false,
+      error: null,
+      refreshCategories: vi.fn(),
+    })
   })
 
   it('should render category tag management page', () => {
@@ -74,6 +85,9 @@ describe('CategoryTagManagement', () => {
     render(<CategoryTagManagement />)
 
     expect(screen.getByText('カテゴリー・タグ管理')).toBeInTheDocument()
+    expect(screen.getByText('支出カテゴリー管理')).toBeInTheDocument()
+    expect(screen.queryByText('収入カテゴリー管理')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /収入カテゴリーを表示/ })).toBeInTheDocument()
     expect(screen.getByText('Test User')).toBeInTheDocument()
   })
 
@@ -105,8 +119,8 @@ describe('CategoryTagManagement', () => {
 
     render(<CategoryTagManagement />)
 
-    const categoryButton = screen.getByText(/カテゴリーを追加/)
-    await userEvent.click(categoryButton)
+    const categoryButtons = screen.getAllByText(/カテゴリーを追加/)
+    await userEvent.click(categoryButtons[0])
 
     await waitFor(() => {
       expect(screen.getByTestId('category-form')).toBeInTheDocument()

--- a/src/pages/CategoryTagManagement/CategoryTagManagement.tsx
+++ b/src/pages/CategoryTagManagement/CategoryTagManagement.tsx
@@ -17,16 +17,20 @@ import {
 } from '@dnd-kit/sortable'
 import { useAuth } from '../../context/AuthContext'
 import { useCategories } from '../../hooks/useCategories'
+import { useIncomeCategories } from '../../hooks/useIncomeCategories'
 import { useTags } from '../../hooks/useTags'
 import { useUserName } from '../../hooks/useUserName'
 import { CategoryForm } from '../../components/CategoryForm'
 import { TagForm } from '../../components/TagForm'
 import { CategoryModal } from '../../components/CategoryModal'
+import { IncomeCategoryModal } from '../../components/IncomeCategoryModal'
 import { TagModal } from '../../components/TagModal'
 import { SortableCategoryItem } from '../../components/SortableCategoryItem'
 import { SortableTagItem } from '../../components/SortableTagItem'
 import { categoryService } from '../../services/categoryService'
+import { incomeCategoryService } from '../../services/incomeCategoryService'
 import { tagService } from '../../services/tagService'
+import { DEFAULT_INCOME_CATEGORIES } from '../../constants/defaultIncomeCategories'
 import type { Category, Tag } from '../../types'
 import './CategoryTagManagement.css'
 
@@ -35,13 +39,22 @@ const CategoryTagManagement = () => {
   const navigate = useNavigate()
   const { displayName, loading: loadingName } = useUserName(user)
 
-  const { categories, refreshCategories } = useCategories()
-  const { allTags, refreshTags } = useTags()
-
   const [showCategoryForm, setShowCategoryForm] = useState<boolean>(false)
+  const [showIncomeCategoryForm, setShowIncomeCategoryForm] = useState(false)
+  /** 収入カテゴリー管理は普段閉じる */
+  const [showIncomeCategorySection, setShowIncomeCategorySection] = useState(false)
   const [showTagForm, setShowTagForm] = useState<boolean>(false)
   const [editingCategory, setEditingCategory] = useState<Category | null>(null)
+  const [editingIncomeCategory, setEditingIncomeCategory] = useState<Category | null>(null)
   const [editingTag, setEditingTag] = useState<Tag | null>(null)
+  const [seedingIncomeCategories, setSeedingIncomeCategories] = useState(false)
+
+  const { categories, refreshCategories } = useCategories()
+  const {
+    categories: incomeCategories,
+    refreshCategories: refreshIncomeCategories,
+  } = useIncomeCategories({ enabled: showIncomeCategorySection })
+  const { allTags, refreshTags } = useTags()
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -63,6 +76,31 @@ const CategoryTagManagement = () => {
     setShowCategoryForm(false)
     setEditingCategory(null)
     refreshCategories()
+  }
+
+  const handleIncomeCategorySuccess = () => {
+    setShowIncomeCategoryForm(false)
+    setEditingIncomeCategory(null)
+    void refreshIncomeCategories()
+  }
+
+  const handleSeedIncomeCategories = async () => {
+    setSeedingIncomeCategories(true)
+    try {
+      const existing = new Set(incomeCategories.map((c) => c.name.toLowerCase()))
+      for (const name of DEFAULT_INCOME_CATEGORIES) {
+        if (!existing.has(name.toLowerCase())) {
+          await incomeCategoryService.createCategory({ name })
+        }
+      }
+      await refreshIncomeCategories()
+      alert('収入カテゴリーの初期データを追加しました')
+    } catch (error) {
+      console.error('Failed to seed income categories', error)
+      alert('初期データの追加に失敗しました')
+    } finally {
+      setSeedingIncomeCategories(false)
+    }
   }
 
   const handleTagSuccess = () => {
@@ -136,6 +174,26 @@ const CategoryTagManagement = () => {
     }
   }
 
+  const handleIncomeCategoryDragEnd = async (event: DragEndEvent) => {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+
+    const oldIndex = incomeCategories.findIndex((cat) => cat.id === active.id)
+    const newIndex = incomeCategories.findIndex((cat) => cat.id === over.id)
+    if (oldIndex === -1 || newIndex === -1) return
+
+    const newCategories = arrayMove(incomeCategories, oldIndex, newIndex)
+    const updates = newCategories.map((cat, index) => ({ id: cat.id, order: index }))
+
+    try {
+      await incomeCategoryService.updateCategoriesOrder(updates)
+      await refreshIncomeCategories()
+    } catch (error) {
+      console.error('Failed to update income category order', error)
+      alert('順序の更新に失敗しました')
+    }
+  }
+
   const handleTagDragEnd = async (event: DragEndEvent, categoryId: string) => {
     const { active, over } = event
 
@@ -185,17 +243,17 @@ const CategoryTagManagement = () => {
           <span className="management-user-name">
             {loadingName ? '読み込み中…' : displayName ?? 'ゲスト'}
           </span>
-          <button className="management-signout-button" onClick={handleSignOut}>
+          <button className="management-signout-button" onClick={() => void handleSignOut()}>
             ログアウト
           </button>
         </div>
       </header>
 
       <main className="management-content">
-        {/* カテゴリー作成セクション */}
+        {/* 支出カテゴリー作成セクション */}
         <section className="management-card category-section">
           <div className="section-header">
-            <h2>カテゴリー管理</h2>
+            <h2>支出カテゴリー管理</h2>
             <button
               className="toggle-form-button"
               onClick={() => {
@@ -224,7 +282,7 @@ const CategoryTagManagement = () => {
               <DndContext
                 sensors={sensors}
                 collisionDetection={closestCenter}
-                onDragEnd={handleCategoryDragEnd}
+                onDragEnd={(e) => void handleCategoryDragEnd(e)}
               >
                 <SortableContext
                   items={categories.map((cat) => cat.id)}
@@ -253,6 +311,102 @@ const CategoryTagManagement = () => {
               onSuccess={handleCategoryModalSuccess}
               onDelete={handleCategoryModalDelete}
             />
+          )}
+        </section>
+
+        {/* 収入カテゴリー（普段は閉じる） */}
+        <section className="management-card category-section income-category-toggle-card">
+          <button
+            type="button"
+            className="income-section-toggle"
+            aria-expanded={showIncomeCategorySection}
+            onClick={() => setShowIncomeCategorySection((v) => !v)}
+          >
+            <span>
+              {showIncomeCategorySection ? '収入カテゴリーを閉じる' : '収入カテゴリーを表示'}
+            </span>
+            <span className="income-section-toggle-icon" aria-hidden="true">
+              {showIncomeCategorySection ? '▲' : '▼'}
+            </span>
+          </button>
+
+          {showIncomeCategorySection && (
+            <>
+              <div className="section-header">
+                <h2>収入カテゴリー管理</h2>
+                <div className="section-header-actions">
+                  {incomeCategories.length === 0 && (
+                    <button
+                      type="button"
+                      className="toggle-form-button"
+                      disabled={seedingIncomeCategories}
+                      onClick={() => void handleSeedIncomeCategories()}
+                    >
+                      {seedingIncomeCategories ? '追加中…' : '初期データを追加'}
+                    </button>
+                  )}
+                  <button
+                    type="button"
+                    className="toggle-form-button"
+                    onClick={() => {
+                      if (editingIncomeCategory) setEditingIncomeCategory(null)
+                      setShowIncomeCategoryForm(!showIncomeCategoryForm)
+                    }}
+                  >
+                    {showIncomeCategoryForm ? 'フォームを閉じる' : 'カテゴリーを追加'}
+                  </button>
+                </div>
+              </div>
+
+              {showIncomeCategoryForm && (
+                <CategoryForm
+                  categories={incomeCategories}
+                  onSuccess={handleIncomeCategorySuccess}
+                  api={incomeCategoryService}
+                  namePlaceholder="例: 給与"
+                  inputId="incomeCategoryName"
+                />
+              )}
+
+              <div className="items-list">
+                <h3>登録済み収入カテゴリー</h3>
+                {incomeCategories.length === 0 ? (
+                  <p className="empty-message">
+                    収入カテゴリーが登録されていません。「初期データを追加」または「カテゴリーを追加」から登録できます。
+                  </p>
+                ) : (
+                  <DndContext
+                    sensors={sensors}
+                    collisionDetection={closestCenter}
+                    onDragEnd={(e) => void handleIncomeCategoryDragEnd(e)}
+                  >
+                    <SortableContext
+                      items={incomeCategories.map((cat) => cat.id)}
+                      strategy={verticalListSortingStrategy}
+                    >
+                      <ul className="items-list-items">
+                        {incomeCategories.map((category) => (
+                          <SortableCategoryItem
+                            key={category.id}
+                            category={category}
+                            onEdit={setEditingIncomeCategory}
+                          />
+                        ))}
+                      </ul>
+                    </SortableContext>
+                  </DndContext>
+                )}
+              </div>
+
+              {editingIncomeCategory && (
+                <IncomeCategoryModal
+                  category={editingIncomeCategory}
+                  categories={incomeCategories}
+                  onClose={() => setEditingIncomeCategory(null)}
+                  onSuccess={() => void refreshIncomeCategories()}
+                />
+              )}
+            </>
           )}
         </section>
 

--- a/src/pages/Dashboard/Dashboard.css
+++ b/src/pages/Dashboard/Dashboard.css
@@ -160,8 +160,38 @@
 .category-tag-section,
 .expense-form-section,
 .expenses-section,
+.income-toggle-section,
 .monthly-summary-section {
   grid-column: 1 / -1;
+}
+
+.income-toggle-section {
+  padding: 0.75rem 1.25rem;
+}
+
+.income-section-toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.65rem 0.25rem;
+  border: none;
+  background: transparent;
+  color: #334155;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.income-section-toggle:hover {
+  color: #0f172a;
+}
+
+.income-section-toggle-icon {
+  font-size: 0.75rem;
+  opacity: 0.7;
 }
 
 .monthly-summary-section {
@@ -230,7 +260,8 @@
 }
 
 .monthly-summary-link,
-.monthly-search-link {
+.monthly-search-link,
+.monthly-budget-link {
   color: #fff;
   text-decoration: none;
   font-weight: 600;
@@ -243,7 +274,8 @@
 }
 
 .monthly-summary-link:hover,
-.monthly-search-link:hover {
+.monthly-search-link:hover,
+.monthly-budget-link:hover {
   background-color: rgba(255, 255, 255, 0.2);
   border-color: rgba(255, 255, 255, 0.5);
 }
@@ -255,10 +287,37 @@
   gap: 0.5rem;
 }
 
+.monthly-totals-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem 2rem;
+  width: 100%;
+  margin-bottom: 0.5rem;
+}
+
+.monthly-total-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
 .monthly-total-amount {
   font-size: 2.5rem;
   font-weight: 700;
   line-height: 1;
+}
+
+.monthly-total-amount--income {
+  font-size: 1.75rem;
+  color: #bbf7d0;
+}
+
+.monthly-total-amount--balance {
+  font-size: 1.75rem;
+}
+
+.monthly-total-amount--negative {
+  color: #fecaca;
 }
 
 .monthly-total-label {
@@ -373,6 +432,11 @@
 .expense-amount {
   font-weight: 600;
   color: #0f172a;
+}
+
+.income-amount {
+  font-weight: 600;
+  color: #059669;
 }
 
 .tags-container {

--- a/src/pages/Dashboard/Dashboard.test.tsx
+++ b/src/pages/Dashboard/Dashboard.test.tsx
@@ -3,6 +3,10 @@ import { render, screen, waitFor } from '../../test/testUtils'
 import Dashboard from './Dashboard'
 import { useAuth } from '../../context/AuthContext'
 import { useDashboardExpenses } from '../../hooks/useDashboardExpenses'
+import { useTotalMonthBudget } from '../../hooks/useTotalMonthBudget'
+import { useMonthBudgetCarryover } from '../../hooks/useMonthBudgetCarryover'
+import { useMonthScopedBudgets } from '../../hooks/useMonthScopedBudgets'
+import { useDashboardIncomes } from '../../hooks/useDashboardIncomes'
 import { useUserName } from '../../hooks/useUserName'
 import type { User } from 'firebase/auth'
 
@@ -16,6 +20,46 @@ vi.mock('../../hooks/useDashboardExpenses', async (importOriginal) => {
   }
 })
 vi.mock('../../hooks/useUserName')
+vi.mock('../../hooks/useTotalMonthBudget', () => ({
+  useTotalMonthBudget: vi.fn(() => ({
+    totalBudget: null,
+    loading: false,
+    error: null,
+  })),
+}))
+
+vi.mock('../../hooks/useMonthBudgetCarryover', () => ({
+  useMonthBudgetCarryover: vi.fn(() => ({
+    carryover: null,
+    loading: false,
+    error: null,
+  })),
+}))
+
+vi.mock('../../hooks/useMonthScopedBudgets', () => ({
+  useMonthScopedBudgets: vi.fn(() => ({
+    categoryBudgets: [],
+    tagBudgets: [],
+    loading: false,
+    error: null,
+  })),
+}))
+
+vi.mock('../../hooks/useDashboardIncomes', () => ({
+  useDashboardIncomes: vi.fn(() => ({
+    incomes: [],
+    monthIncomesAll: [],
+    loading: false,
+    monthlyTotal: 0,
+    monthlyLoading: false,
+    currentPage: 1,
+    totalPages: 1,
+    goToPage: vi.fn(),
+    refreshAfterMutation: vi.fn(),
+    error: null,
+    monthIncomeCount: 0,
+  })),
+}))
 vi.mock('../../components/ExpenseForm', () => ({
   ExpenseForm: () => <div data-testid="expense-form">Expense Form</div>,
 }))
@@ -28,6 +72,19 @@ vi.mock('../../components/ExpensesTable', () => ({
 }))
 vi.mock('../../components/ExpenseModal', () => ({
   ExpenseModal: () => <div data-testid="expense-modal">Expense Modal</div>,
+}))
+vi.mock('../../components/IncomeForm', () => ({
+  IncomeForm: () => <div data-testid="income-form">Income Form</div>,
+}))
+vi.mock('../../components/IncomesTable', () => ({
+  IncomesTable: ({ incomes, loading }: { incomes: unknown[]; loading: boolean }) => (
+    <div data-testid="incomes-table">
+      {loading ? '読み込み中…' : `Incomes: ${incomes.length}`}
+    </div>
+  ),
+}))
+vi.mock('../../components/IncomeModal', () => ({
+  IncomeModal: () => <div data-testid="income-modal">Income Modal</div>,
 }))
 
 const mockUser = {
@@ -55,6 +112,9 @@ const mockUser = {
 
 const defaultDashboardExpensesMock = {
   expenses: [],
+  monthExpensesAll: [],
+  monthExpensesAllLoading: false,
+  ensureMonthExpensesAll: vi.fn(async () => []),
   loading: false,
   monthlyTotal: 0,
   monthlyLoading: false,
@@ -74,6 +134,35 @@ const defaultDashboardExpensesMock = {
 describe('Dashboard', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(useTotalMonthBudget).mockReturnValue({
+      totalBudget: null,
+      loading: false,
+      error: null,
+    })
+    vi.mocked(useMonthBudgetCarryover).mockReturnValue({
+      carryover: null,
+      loading: false,
+      error: null,
+    })
+    vi.mocked(useMonthScopedBudgets).mockReturnValue({
+      categoryBudgets: [],
+      tagBudgets: [],
+      loading: false,
+      error: null,
+    })
+    vi.mocked(useDashboardIncomes).mockReturnValue({
+      incomes: [],
+      monthIncomesAll: [],
+      loading: false,
+      monthlyTotal: 0,
+      monthlyLoading: false,
+      currentPage: 1,
+      totalPages: 1,
+      goToPage: vi.fn(),
+      refreshAfterMutation: vi.fn(),
+      error: null,
+      monthIncomeCount: 0,
+    })
   })
 
   it('should render dashboard with user information', async () => {
@@ -132,7 +221,32 @@ describe('Dashboard', () => {
 
     render(<Dashboard />)
 
-    expect(screen.getByText(/月の合計金額/)).toBeInTheDocument()
+    expect(screen.getByText('支出合計')).toBeInTheDocument()
+    expect(screen.getByText('収入合計')).toBeInTheDocument()
+    expect(screen.queryByText('収支（収入−支出）')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /収入を表示/ })).toBeInTheDocument()
+  })
+
+  it('should show income form and list when income section is opened', async () => {
+    const userEvent = (await import('@testing-library/user-event')).default.setup()
+
+    vi.mocked(useAuth).mockReturnValue({
+      user: mockUser,
+      loading: false,
+      signOutUser: vi.fn(),
+    })
+    vi.mocked(useUserName).mockReturnValue({
+      displayName: 'Test User',
+      loading: false,
+    })
+    vi.mocked(useDashboardExpenses).mockReturnValue({ ...defaultDashboardExpensesMock })
+
+    render(<Dashboard />)
+
+    await userEvent.click(screen.getByRole('button', { name: /収入を表示/ }))
+
+    expect(screen.getByText('収入を登録')).toBeInTheDocument()
+    expect(screen.getByTestId('incomes-table')).toBeInTheDocument()
   })
 
   it('should show expense form when button is clicked', async () => {
@@ -251,6 +365,119 @@ describe('Dashboard', () => {
       'href',
       '/monthly-summary'
     )
+    const ym = defaultDashboardExpensesMock.selectedYearMonth
+    expect(screen.getByRole('link', { name: /予算設定/ })).toHaveAttribute(
+      'href',
+      `/budget?year=${ym.year}&month=${ym.month}`
+    )
+  })
+
+  it('should show budget progress when monthly total is loaded and budget exists', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: mockUser,
+      loading: false,
+      signOutUser: vi.fn(),
+    })
+    vi.mocked(useUserName).mockReturnValue({
+      displayName: 'Test User',
+      loading: false,
+    })
+    vi.mocked(useDashboardExpenses).mockReturnValue({
+      ...defaultDashboardExpensesMock,
+      monthlyTotal: 40_000,
+      monthlyLoading: false,
+    })
+    vi.mocked(useTotalMonthBudget).mockReturnValue({
+      totalBudget: {
+        id: '2026_04',
+        userId: 'test-uid',
+        year: 2026,
+        month: 4,
+        amountLimit: 100_000,
+        categoryId: null,
+        categoryName: null,
+        tagId: null,
+        tagName: null,
+        updatedAt: {} as import('firebase/firestore').Timestamp,
+      },
+      loading: false,
+      error: null,
+    })
+
+    render(<Dashboard />)
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+    expect(screen.getByText(/残り/)).toBeInTheDocument()
+  })
+
+  it('should show category and tag budget progress when scoped budgets exist', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: mockUser,
+      loading: false,
+      signOutUser: vi.fn(),
+    })
+    vi.mocked(useUserName).mockReturnValue({
+      displayName: 'Test User',
+      loading: false,
+    })
+    vi.mocked(useDashboardExpenses).mockReturnValue({
+      ...defaultDashboardExpensesMock,
+      monthlyTotal: 4000,
+      monthlyLoading: false,
+      monthExpensesAll: [
+        {
+          id: '1',
+          date: {} as import('firebase/firestore').Timestamp,
+          amount: 4000,
+          userId: 'test-uid',
+          bigCategory: '食費',
+          tags: 'ランチ',
+          paymentMethod: '',
+          description: '',
+          createdAt: {} as import('firebase/firestore').Timestamp,
+          updatedAt: {} as import('firebase/firestore').Timestamp,
+        },
+      ],
+    })
+    vi.mocked(useMonthScopedBudgets).mockReturnValue({
+      categoryBudgets: [
+        {
+          id: 'c',
+          userId: 'test-uid',
+          year: 2026,
+          month: 4,
+          amountLimit: 10000,
+          categoryId: 'cat1',
+          categoryName: '食費',
+          tagId: null,
+          tagName: null,
+          updatedAt: {} as import('firebase/firestore').Timestamp,
+        },
+      ],
+      tagBudgets: [
+        {
+          id: 't',
+          userId: 'test-uid',
+          year: 2026,
+          month: 4,
+          amountLimit: 3000,
+          categoryId: null,
+          categoryName: null,
+          tagId: 'tag1',
+          tagName: 'ランチ',
+          updatedAt: {} as import('firebase/firestore').Timestamp,
+        },
+      ],
+      loading: false,
+      error: null,
+    })
+
+    render(<Dashboard />)
+
+    expect(screen.getByText('カテゴリー別予算')).toBeInTheDocument()
+    expect(screen.getByText('タグ別予算')).toBeInTheDocument()
+    expect(screen.getByText('食費')).toBeInTheDocument()
+    expect(screen.getByText('ランチ')).toBeInTheDocument()
   })
 })
 

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -1,14 +1,23 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
 import { useAuth } from '../../context/AuthContext'
 import { useDashboardExpenses, getCurrentYearMonth } from '../../hooks/useDashboardExpenses'
+import { useDashboardIncomes } from '../../hooks/useDashboardIncomes'
 import { useUserName } from '../../hooks/useUserName'
 import { ExpenseForm } from '../../components/ExpenseForm'
 import { ExpensesTable } from '../../components/ExpensesTable'
 import { ExpenseModal } from '../../components/ExpenseModal'
+import { IncomeForm } from '../../components/IncomeForm'
+import { IncomesTable } from '../../components/IncomesTable'
+import { IncomeModal } from '../../components/IncomeModal'
 import { Pagination } from '../../components/Pagination'
+import { BudgetProgressBar } from '../../components/BudgetProgressBar'
+import { BudgetScopedProgress } from '../../components/BudgetScopedProgress'
+import { useTotalMonthBudget } from '../../hooks/useTotalMonthBudget'
+import { useMonthBudgetCarryover } from '../../hooks/useMonthBudgetCarryover'
+import { useMonthScopedBudgets } from '../../hooks/useMonthScopedBudgets'
 import { buildDashboardYearOptions, isSameYearMonth } from '../../utils/dashboardYearMonth'
-import type { Expense } from '../../types'
+import type { Expense, Income } from '../../types'
 import './Dashboard.css'
 
 const Dashboard = () => {
@@ -18,6 +27,9 @@ const Dashboard = () => {
 
   const {
     expenses,
+    monthExpensesAll,
+    monthExpensesAllLoading,
+    ensureMonthExpensesAll,
     loading: loadingExpenses,
     monthlyTotal,
     monthlyLoading,
@@ -30,6 +42,50 @@ const Dashboard = () => {
     selectedYearMonth,
     setSelectedYearMonth,
   } = useDashboardExpenses(user?.uid)
+
+  const [showExpenseForm, setShowExpenseForm] = useState(false)
+  const [showIncomeForm, setShowIncomeForm] = useState(false)
+  /** 収入まわりは普段閉じる */
+  const [showIncomeSection, setShowIncomeSection] = useState(false)
+  const [selectedExpense, setSelectedExpense] = useState<Expense | null>(null)
+  const [selectedIncome, setSelectedIncome] = useState<Income | null>(null)
+
+  const {
+    incomes,
+    loading: loadingIncomes,
+    monthlyTotal: monthlyIncomeTotal,
+    monthlyLoading: incomeSummaryLoading,
+    currentPage: incomeListPage,
+    totalPages: incomeListTotalPages,
+    goToPage: goToIncomePage,
+    refreshAfterMutation: refreshIncomesAfterMutation,
+    error: incomeListError,
+    monthIncomeCount,
+  } = useDashboardIncomes(user?.uid, selectedYearMonth, showIncomeSection)
+
+  const { totalBudget, loading: budgetLoading } = useTotalMonthBudget(
+    user?.uid,
+    selectedYearMonth.year,
+    selectedYearMonth.month
+  )
+  const { carryover, loading: carryoverLoading } = useMonthBudgetCarryover(
+    user?.uid,
+    selectedYearMonth.year,
+    selectedYearMonth.month
+  )
+  const {
+    categoryBudgets,
+    tagBudgets,
+    loading: scopedBudgetLoading,
+  } = useMonthScopedBudgets(user?.uid, selectedYearMonth.year, selectedYearMonth.month)
+
+  const needsScopedExpenses = categoryBudgets.length > 0 || tagBudgets.length > 0
+
+  useEffect(() => {
+    if (needsScopedExpenses) {
+      void ensureMonthExpensesAll()
+    }
+  }, [needsScopedExpenses, ensureMonthExpensesAll, selectedYearMonth])
 
   const isViewingCurrentMonth = isSameYearMonth(selectedYearMonth, getCurrentYearMonth())
 
@@ -46,8 +102,9 @@ const Dashboard = () => {
     ? '今月の支出一覧'
     : `${selectedYearMonth.year}年${selectedYearMonth.month}月の支出一覧`
 
-  const [showForm, setShowForm] = useState<boolean>(false)
-  const [selectedExpense, setSelectedExpense] = useState<Expense | null>(null)
+  const incomeListHeading = isViewingCurrentMonth
+    ? '今月の収入一覧'
+    : `${selectedYearMonth.year}年${selectedYearMonth.month}月の収入一覧`
 
   const handleSignOut = async () => {
     try {
@@ -59,28 +116,18 @@ const Dashboard = () => {
   }
 
   const handleExpenseSuccess = async () => {
-    setShowForm(false)
+    setShowExpenseForm(false)
     await refreshAfterMutation()
   }
 
-  const handleExpenseClick = (expense: Expense) => {
-    setSelectedExpense(expense)
-  }
-
-  const handleModalClose = () => {
-    setSelectedExpense(null)
-  }
-
-  const handleExpenseUpdate = async () => {
-    await refreshAfterMutation()
-  }
-
-  const handleExpenseDelete = async () => {
-    await refreshAfterMutation()
+  const handleIncomeSuccess = async () => {
+    setShowIncomeForm(false)
+    await refreshIncomesAfterMutation()
   }
 
   const listBusy = loadingExpenses
-  const summaryBusy = monthlyLoading
+  const incomeListBusy = loadingIncomes
+  const summaryBusy = monthlyLoading || incomeSummaryLoading
 
   return (
     <div className="dashboard-page">
@@ -93,7 +140,7 @@ const Dashboard = () => {
           <Link to="/category-tag-management" className="management-link">
             カテゴリー・タグ管理
           </Link>
-          <button className="dashboard-signout-button" onClick={handleSignOut}>
+          <button className="dashboard-signout-button" onClick={() => void handleSignOut()}>
             ログアウト
           </button>
         </div>
@@ -110,6 +157,12 @@ const Dashboard = () => {
               <Link to="/monthly-expenses" className="monthly-search-link">
                 支出を検索 →
               </Link>
+              <Link
+                to={`/budget?year=${selectedYearMonth.year}&month=${selectedYearMonth.month}`}
+                className="monthly-budget-link"
+              >
+                予算設定 →
+              </Link>
             </div>
           </div>
           <div className="monthly-total">
@@ -117,14 +170,38 @@ const Dashboard = () => {
               <p className="loading-text">読み込み中...</p>
             ) : (
               <>
-                <span className="monthly-total-amount">
-                  ¥{monthlyTotal.toLocaleString()}
-                </span>
-                <p className="monthly-total-label">
-                  {isViewingCurrentMonth
-                    ? `${selectedYearMonth.month}月の合計金額`
-                    : `${selectedYearMonth.year}年${selectedYearMonth.month}月の合計金額`}
-                </p>
+                <div className="monthly-totals-grid">
+                  <div className="monthly-total-block">
+                    <span className="monthly-total-amount">
+                      ¥{monthlyTotal.toLocaleString()}
+                    </span>
+                    <p className="monthly-total-label">支出合計</p>
+                  </div>
+                  <div className="monthly-total-block">
+                    <span className="monthly-total-amount monthly-total-amount--income">
+                      ¥{monthlyIncomeTotal.toLocaleString()}
+                    </span>
+                    <p className="monthly-total-label">収入合計</p>
+                  </div>
+                </div>
+                <BudgetProgressBar
+                  used={monthlyTotal}
+                  limit={totalBudget?.amountLimit ?? null}
+                  carryIn={carryover?.carryIn ?? 0}
+                  loading={budgetLoading || carryoverLoading}
+                  budgetSettingsTo={`/budget?year=${selectedYearMonth.year}&month=${selectedYearMonth.month}`}
+                />
+                <BudgetScopedProgress
+                  expenses={monthExpensesAll}
+                  categoryBudgets={categoryBudgets}
+                  tagBudgets={tagBudgets}
+                  loading={
+                    scopedBudgetLoading ||
+                    summaryBusy ||
+                    (needsScopedExpenses && monthExpensesAllLoading)
+                  }
+                  budgetSettingsTo={`/budget?year=${selectedYearMonth.year}&month=${selectedYearMonth.month}`}
+                />
               </>
             )}
           </div>
@@ -136,14 +213,13 @@ const Dashboard = () => {
             <button
               type="button"
               className="toggle-form-button"
-              onClick={() => setShowForm(!showForm)}
+              onClick={() => setShowExpenseForm(!showExpenseForm)}
             >
-              {showForm ? 'フォームを閉じる' : '支出を追加'}
+              {showExpenseForm ? 'フォームを閉じる' : '支出を追加'}
             </button>
           </div>
-
-          {showForm && user?.uid && (
-            <ExpenseForm userId={user.uid} onSuccess={handleExpenseSuccess} />
+          {showExpenseForm && user?.uid && (
+            <ExpenseForm userId={user.uid} onSuccess={() => void handleExpenseSuccess()} />
           )}
         </section>
 
@@ -212,7 +288,7 @@ const Dashboard = () => {
           <ExpensesTable
             expenses={expenses}
             loading={listBusy}
-            onExpenseClick={handleExpenseClick}
+            onExpenseClick={setSelectedExpense}
           />
           <Pagination
             currentPage={expenseListPage}
@@ -220,15 +296,91 @@ const Dashboard = () => {
             onPageChange={(p) => void goToPage(p)}
           />
         </section>
+
+        <section className="dashboard-card income-toggle-section">
+          <button
+            type="button"
+            className="income-section-toggle"
+            aria-expanded={showIncomeSection}
+            onClick={() => setShowIncomeSection((v) => !v)}
+          >
+            <span>{showIncomeSection ? '収入を閉じる' : '収入を表示'}</span>
+            <span className="income-section-toggle-icon" aria-hidden="true">
+              {showIncomeSection ? '▲' : '▼'}
+            </span>
+          </button>
+        </section>
+
+        {showIncomeSection && (
+          <>
+            <section className="dashboard-card expense-form-section">
+              <div className="expense-form-header">
+                <h2>収入を登録</h2>
+                <button
+                  type="button"
+                  className="toggle-form-button"
+                  onClick={() => setShowIncomeForm(!showIncomeForm)}
+                >
+                  {showIncomeForm ? 'フォームを閉じる' : '収入を追加'}
+                </button>
+              </div>
+              {showIncomeForm && user?.uid && (
+                <IncomeForm userId={user.uid} onSuccess={() => void handleIncomeSuccess()} />
+              )}
+            </section>
+
+            <section className="dashboard-card expenses-section">
+              <div className="expenses-section-header">
+                <div className="expenses-section-heading-row">
+                  <h2>{incomeListHeading}</h2>
+                  <div className="expenses-section-controls">
+                    <span className="dashboard-expense-count" aria-live="polite">
+                      {incomeListBusy ? '読み込み中…' : `${monthIncomeCount}件`}
+                    </span>
+                  </div>
+                </div>
+              </div>
+              {incomeListError && (
+                <p className="dashboard-list-error" role="alert">
+                  収入一覧の取得に失敗しました。Firestore の複合インデックス（incomes: userId + date
+                  降順）が有効か確認してください。
+                  {incomeListError.message ? (
+                    <span className="dashboard-list-error-detail">{incomeListError.message}</span>
+                  ) : null}
+                </p>
+              )}
+              <IncomesTable
+                incomes={incomes}
+                loading={incomeListBusy}
+                onIncomeClick={setSelectedIncome}
+              />
+              <Pagination
+                currentPage={incomeListPage}
+                totalPages={incomeListTotalPages}
+                onPageChange={(p) => void goToIncomePage(p)}
+              />
+            </section>
+          </>
+        )}
       </main>
 
       {selectedExpense && user?.uid && (
         <ExpenseModal
           expense={selectedExpense}
           userId={user.uid}
-          onClose={handleModalClose}
-          onUpdate={handleExpenseUpdate}
-          onDelete={handleExpenseDelete}
+          onClose={() => setSelectedExpense(null)}
+          onUpdate={() => void refreshAfterMutation()}
+          onDelete={() => void refreshAfterMutation()}
+        />
+      )}
+
+      {selectedIncome && user?.uid && (
+        <IncomeModal
+          income={selectedIncome}
+          userId={user.uid}
+          onClose={() => setSelectedIncome(null)}
+          onUpdate={() => void refreshIncomesAfterMutation()}
+          onDelete={() => void refreshIncomesAfterMutation()}
         />
       )}
     </div>

--- a/src/pages/MonthlyExpenses/MonthlyExpenses.tsx
+++ b/src/pages/MonthlyExpenses/MonthlyExpenses.tsx
@@ -15,11 +15,6 @@ const MonthlyExpenses = () => {
   const [searchParams] = useSearchParams()
   const { displayName, loading: loadingName } = useUserName(user)
 
-  // カスタムフックを使用してデータを取得
-  const { expenses, loading: loadingExpenses } = useExpenses(user?.uid)
-  const { categories, loading: loadingCategories } = useCategories()
-  const { allTags, loading: loadingTags } = useTags()
-
   // 現在の年月をデフォルト値として設定
   const now = new Date()
   const currentYear = now.getFullYear()
@@ -41,6 +36,14 @@ const MonthlyExpenses = () => {
   const [selectedCategory, setSelectedCategory] = useState<string>(() => urlCategory ?? '')
   const [selectedTag, setSelectedTag] = useState<string>(() => urlTag ?? '')
   const [selectedPaymentMethods, setSelectedPaymentMethods] = useState<string[]>([])
+
+  // 選択年月があるときはその月だけ取得（読取抑制）
+  const { expenses, loading: loadingExpenses } = useExpenses(user?.uid, {
+    year: selectedYear,
+    month: selectedMonth,
+  })
+  const { categories, loading: loadingCategories } = useCategories()
+  const { allTags, loading: loadingTags } = useTags()
 
   // 選択されたカテゴリーに基づいてタグをフィルタリング
   const filteredTags = useMemo(() => {

--- a/src/pages/MonthlySummary/MonthlySummary.tsx
+++ b/src/pages/MonthlySummary/MonthlySummary.tsx
@@ -42,7 +42,9 @@ const MonthlySummary = () => {
   const { user, signOutUser } = useAuth()
   const navigate = useNavigate()
   const { displayName, loading: loadingName } = useUserName(user)
-  const { expenses, loading: loadingExpenses } = useExpenses(user?.uid)
+  const { expenses, loading: loadingExpenses } = useExpenses(user?.uid, {
+    recentMonths: 24,
+  })
   const { categories } = useCategories()
   const { allTags } = useTags()
 

--- a/src/services/budgetService.test.ts
+++ b/src/services/budgetService.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest'
+import { Timestamp } from 'firebase/firestore'
+
+vi.mock('../firebase/config', () => ({
+  db: {},
+  auth: {},
+}))
+
+const { budgetDocId, monthlyBudgetFromFirestore } = await import('../services/budgetService')
+
+describe('budgetDocId', () => {
+  it('builds total budget id', () => {
+    expect(budgetDocId(2026, 3)).toBe('2026_03')
+  })
+
+  it('builds category and tag budget ids', () => {
+    expect(budgetDocId(2026, 3, { categoryId: 'cat1' })).toBe('2026_03__cat__cat1')
+    expect(budgetDocId(2026, 3, { tagId: 'tag1' })).toBe('2026_03__tag__tag1')
+  })
+
+  it('prefers tagId when both are provided', () => {
+    expect(budgetDocId(2026, 3, { categoryId: 'cat1', tagId: 'tag1' })).toBe(
+      '2026_03__tag__tag1'
+    )
+  })
+})
+
+describe('monthlyBudgetFromFirestore', () => {
+  it('maps fields with defaults', () => {
+    const updatedAt = Timestamp.now()
+    const b = monthlyBudgetFromFirestore('2026_03', {
+      userId: 'u1',
+      year: 2026,
+      month: 3,
+      amountLimit: 10000,
+      categoryId: null,
+      tagId: null,
+      updatedAt,
+    })
+    expect(b).toMatchObject({
+      id: '2026_03',
+      userId: 'u1',
+      year: 2026,
+      month: 3,
+      amountLimit: 10000,
+      categoryId: null,
+      tagId: null,
+    })
+    expect(b.updatedAt).toBe(updatedAt)
+  })
+
+  it('defaults missing amountLimit to 0', () => {
+    const b = monthlyBudgetFromFirestore('x', { userId: 'u1', year: 2026, month: 1 })
+    expect(b.amountLimit).toBe(0)
+  })
+})

--- a/src/services/budgetService.ts
+++ b/src/services/budgetService.ts
@@ -1,0 +1,220 @@
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  setDoc,
+  deleteDoc,
+  query,
+  where,
+  Timestamp,
+  type DocumentData,
+} from 'firebase/firestore'
+import { db } from '../firebase/config'
+import { monthlyTotalPeriodId } from './expenseService'
+import {
+  cacheGet,
+  cacheInvalidatePrefix,
+  cacheSet,
+  totalBudgetYearCacheKey,
+} from '../utils/firestoreReadCache'
+import type { MonthlyBudget, SetBudgetOptions } from '../types'
+
+function budgetsCollection(userId: string) {
+  return collection(db, 'users', userId, 'budgets')
+}
+
+export function budgetDocId(
+  year: number,
+  month: number,
+  options?: Pick<SetBudgetOptions, 'categoryId' | 'tagId'>
+): string {
+  const periodId = monthlyTotalPeriodId(year, month)
+  if (options?.tagId) {
+    return `${periodId}__tag__${options.tagId}`
+  }
+  if (options?.categoryId) {
+    return `${periodId}__cat__${options.categoryId}`
+  }
+  return periodId
+}
+
+export function monthlyBudgetFromFirestore(id: string, d: DocumentData): MonthlyBudget {
+  return {
+    id,
+    userId: (d.userId as string) ?? '',
+    year: (d.year as number) ?? 0,
+    month: (d.month as number) ?? 0,
+    amountLimit: typeof d.amountLimit === 'number' ? d.amountLimit : 0,
+    categoryId: (d.categoryId as string | null | undefined) ?? null,
+    categoryName: (d.categoryName as string | null | undefined) ?? null,
+    tagId: (d.tagId as string | null | undefined) ?? null,
+    tagName: (d.tagName as string | null | undefined) ?? null,
+    createdAt: d.createdAt as MonthlyBudget['createdAt'],
+    updatedAt: (d.updatedAt as MonthlyBudget['updatedAt']) ?? Timestamp.now(),
+  } satisfies MonthlyBudget
+}
+
+export async function getMonthlyTotalBudget(
+  userId: string,
+  year: number,
+  month: number
+): Promise<MonthlyBudget | null> {
+  const id = budgetDocId(year, month)
+  const snap = await getDoc(doc(budgetsCollection(userId), id))
+  if (!snap.exists()) return null
+  return monthlyBudgetFromFirestore(snap.id, snap.data())
+}
+
+export async function getCategoryBudget(
+  userId: string,
+  year: number,
+  month: number,
+  categoryId: string
+): Promise<MonthlyBudget | null> {
+  const id = budgetDocId(year, month, { categoryId })
+  const snap = await getDoc(doc(budgetsCollection(userId), id))
+  if (!snap.exists()) return null
+  return monthlyBudgetFromFirestore(snap.id, snap.data())
+}
+
+export async function getTagBudget(
+  userId: string,
+  year: number,
+  month: number,
+  tagId: string
+): Promise<MonthlyBudget | null> {
+  const id = budgetDocId(year, month, { tagId })
+  const snap = await getDoc(doc(budgetsCollection(userId), id))
+  if (!snap.exists()) return null
+  return monthlyBudgetFromFirestore(snap.id, snap.data())
+}
+
+export async function listBudgetsForMonth(
+  userId: string,
+  year: number,
+  month: number
+): Promise<MonthlyBudget[]> {
+  const q = query(budgetsCollection(userId), where('year', '==', year), where('month', '==', month))
+  const snap = await getDocs(q)
+  const list: MonthlyBudget[] = []
+  snap.forEach((s) => {
+    list.push(monthlyBudgetFromFirestore(s.id, s.data()))
+  })
+  list.sort((a, b) => a.id.localeCompare(b.id, 'en'))
+  return list
+}
+
+/** 指定年の予算ドキュメントをすべて取得（全体・カテゴリー・タグ含む） */
+export async function listBudgetsForYear(userId: string, year: number): Promise<MonthlyBudget[]> {
+  const q = query(budgetsCollection(userId), where('year', '==', year))
+  const snap = await getDocs(q)
+  const list: MonthlyBudget[] = []
+  snap.forEach((s) => {
+    list.push(monthlyBudgetFromFirestore(s.id, s.data()))
+  })
+  list.sort((a, b) => {
+    if (a.month !== b.month) return a.month - b.month
+    return a.id.localeCompare(b.id, 'en')
+  })
+  return list
+}
+
+/** 指定年の全体予算のみ（カテゴリー・タグ別は含めない）。最大12 getDoc。 */
+export async function listTotalBudgetLimitsForYear(
+  userId: string,
+  year: number
+): Promise<Record<number, number | null>> {
+  const cacheKey = totalBudgetYearCacheKey(userId, year)
+  const cached = cacheGet<Record<number, number | null>>(cacheKey)
+  if (cached) return { ...cached }
+
+  const pairs = await Promise.all(
+    Array.from({ length: 12 }, async (_, i) => {
+      const month = i + 1
+      const b = await getMonthlyTotalBudget(userId, year, month)
+      return [month, b?.amountLimit ?? null] as const
+    })
+  )
+  const map: Record<number, number | null> = {}
+  for (const [month, limit] of pairs) {
+    map[month] = limit
+  }
+  cacheSet(cacheKey, map)
+  return map
+}
+
+export function invalidateTotalBudgetYearCache(userId: string): void {
+  cacheInvalidatePrefix(`totalBudget:${userId}:`)
+}
+
+function validateSetBudget(amountLimit: number, options?: SetBudgetOptions): void {
+  if (!Number.isFinite(amountLimit) || amountLimit < 0 || !Number.isInteger(amountLimit)) {
+    throw new Error('予算上限は0以上の整数で指定してください')
+  }
+  const hasCat = Boolean(options?.categoryId)
+  const hasTag = Boolean(options?.tagId)
+  if (hasCat && hasTag) {
+    throw new Error('カテゴリー別とタグ別を同時に指定できません')
+  }
+  if (hasCat && !options?.categoryName) {
+    throw new Error('カテゴリー別予算には categoryName が必要です')
+  }
+  if (hasTag && !options?.tagName) {
+    throw new Error('タグ別予算には tagName が必要です')
+  }
+}
+
+export async function setBudget(
+  userId: string,
+  year: number,
+  month: number,
+  amountLimit: number,
+  options?: SetBudgetOptions
+): Promise<void> {
+  validateSetBudget(amountLimit, options)
+  const id = budgetDocId(year, month, {
+    categoryId: options?.categoryId,
+    tagId: options?.tagId,
+  })
+  const ref = doc(budgetsCollection(userId), id)
+  const existing = await getDoc(ref)
+  const now = Timestamp.now()
+  const hasCat = Boolean(options?.categoryId)
+  const hasTag = Boolean(options?.tagId)
+  await setDoc(
+    ref,
+    {
+      userId,
+      year,
+      month,
+      amountLimit,
+      categoryId: hasCat ? options!.categoryId! : null,
+      categoryName: hasCat ? options!.categoryName! : null,
+      tagId: hasTag ? options!.tagId! : null,
+      tagName: hasTag ? options!.tagName! : null,
+      updatedAt: now,
+      ...(!existing.exists() ? { createdAt: now } : {}),
+    },
+    { merge: true }
+  )
+  if (!hasCat && !hasTag) {
+    invalidateTotalBudgetYearCache(userId)
+  }
+}
+
+export async function deleteBudget(
+  userId: string,
+  year: number,
+  month: number,
+  options?: Pick<SetBudgetOptions, 'categoryId' | 'tagId'>
+): Promise<void> {
+  const id = budgetDocId(year, month, {
+    categoryId: options?.categoryId,
+    tagId: options?.tagId,
+  })
+  await deleteDoc(doc(budgetsCollection(userId), id))
+  if (!options?.categoryId && !options?.tagId) {
+    invalidateTotalBudgetYearCache(userId)
+  }
+}

--- a/src/services/expenseService.ts
+++ b/src/services/expenseService.ts
@@ -7,6 +7,7 @@ import {
   startAfter,
   getDocs,
   getDoc,
+  getCountFromServer,
   doc,
   writeBatch,
   Timestamp,
@@ -16,6 +17,12 @@ import {
   type QueryDocumentSnapshot,
 } from 'firebase/firestore'
 import { db } from '../firebase/config'
+import {
+  cacheGet,
+  cacheInvalidatePrefix,
+  cacheSet,
+  spentYearCacheKey,
+} from '../utils/firestoreReadCache'
 import type { Expense, CreateExpenseInput, UpdateExpenseInput } from '../types'
 
 const COLLECTION = 'expenses'
@@ -26,7 +33,7 @@ export type ExpensePageResult = {
   hasMore: boolean
 }
 
-function monthlyTotalPeriodId(year: number, month: number): string {
+export function monthlyTotalPeriodId(year: number, month: number): string {
   return `${year}_${String(month).padStart(2, '0')}`
 }
 
@@ -128,6 +135,44 @@ export const expenseService = {
     return list
   },
 
+  /** 月の件数のみ（集計クエリ。ドキュメント全件読取より安い） */
+  async getExpenseCountInMonth(userId: string, year: number, month: number): Promise<number> {
+    const { start, end } = monthDateRangeTimestamps(year, month)
+    const q = query(
+      collection(db, COLLECTION),
+      where('userId', '==', userId),
+      where('date', '>=', start),
+      where('date', '<=', end)
+    )
+    const snap = await getCountFromServer(q)
+    return snap.data().count
+  },
+
+  /**
+   * 直近 N か月分の支出。先に monthlyTotals で金額0の月を飛ばし、有支出月だけ getExpensesInMonth。
+   */
+  async getExpensesForRecentMonths(userId: string, monthsBack: number): Promise<Expense[]> {
+    const now = new Date()
+    const periods: { year: number; month: number }[] = []
+    for (let i = 0; i < monthsBack; i++) {
+      const d = new Date(now.getFullYear(), now.getMonth() - i, 1)
+      periods.push({ year: d.getFullYear(), month: d.getMonth() + 1 })
+    }
+
+    const totals = await Promise.all(
+      periods.map((p) => this.getMonthlyTotalForDisplay(userId, p.year, p.month))
+    )
+    const active = periods.filter((_, i) => totals[i] > 0)
+    if (active.length === 0) return []
+
+    const lists = await Promise.all(
+      active.map((p) => this.getExpensesInMonth(userId, p.year, p.month))
+    )
+    const merged = lists.flat()
+    merged.sort((a, b) => (b.date?.toMillis() || 0) - (a.date?.toMillis() || 0))
+    return merged
+  },
+
   /**
    * 指定月のみサーバー側ページング（最大 pageSize+1 件読取）
    */
@@ -211,6 +256,40 @@ export const expenseService = {
     return total
   },
 
+  /**
+   * 指定年の1〜throughMonth の支出合計（円）。セッションキャッシュあり。
+   * throughMonth 省略時は 12。
+   */
+  async getSpentByMonthForYear(
+    userId: string,
+    year: number,
+    throughMonth = 12
+  ): Promise<Record<number, number>> {
+    const end = Math.min(12, Math.max(1, throughMonth))
+    const cacheKey = spentYearCacheKey(userId, year, end)
+    const cached = cacheGet<Record<number, number>>(cacheKey)
+    if (cached) return { ...cached }
+
+    const pairs = await Promise.all(
+      Array.from({ length: end }, async (_, i) => {
+        const month = i + 1
+        const total = await this.getMonthlyTotalForDisplay(userId, year, month)
+        return [month, total] as const
+      })
+    )
+    const map: Record<number, number> = {}
+    for (let m = 1; m <= 12; m++) map[m] = 0
+    for (const [month, total] of pairs) {
+      map[month] = total
+    }
+    cacheSet(cacheKey, map)
+    return map
+  },
+
+  invalidateSpentCaches(userId: string): void {
+    cacheInvalidatePrefix(`spent:${userId}:`)
+  },
+
   async createExpense(userId: string, input: CreateExpenseInput): Promise<string> {
     const now = Timestamp.now()
     const expenseDate = Timestamp.fromDate(input.date)
@@ -231,6 +310,7 @@ export const expenseService = {
     })
     applyMonthlyDeltaInBatch(batch, userId, input.date, input.amount)
     await batch.commit()
+    this.invalidateSpentCaches(userId)
     return expenseRef.id
   },
 
@@ -272,6 +352,7 @@ export const expenseService = {
     }
 
     await batch.commit()
+    this.invalidateSpentCaches(oldUserId)
   },
 
   async deleteExpense(expenseId: string): Promise<void> {
@@ -289,5 +370,6 @@ export const expenseService = {
     batch.delete(expenseRef)
     applyMonthlyDeltaInBatch(batch, userId, expenseDate, -amount)
     await batch.commit()
+    this.invalidateSpentCaches(userId)
   },
 }

--- a/src/services/incomeCategoryService.ts
+++ b/src/services/incomeCategoryService.ts
@@ -1,0 +1,63 @@
+import { collection, getDocs, addDoc, updateDoc, deleteDoc, doc } from 'firebase/firestore'
+import { db } from '../firebase/config'
+import type { Category, CreateCategoryInput } from '../types'
+
+const COLLECTION = 'incomeCategories'
+
+export const incomeCategoryService = {
+  async getAllCategories(): Promise<Category[]> {
+    const categoriesRef = collection(db, COLLECTION)
+    const querySnapshot = await getDocs(categoriesRef)
+
+    const categories: Category[] = []
+    querySnapshot.forEach((d) => {
+      const data = d.data()
+      categories.push({
+        id: d.id,
+        name: data.name || d.id,
+        order: data.order ?? undefined,
+      })
+    })
+
+    categories.sort((a, b) => {
+      const orderA = a.order ?? Infinity
+      const orderB = b.order ?? Infinity
+      if (orderA !== orderB) {
+        return orderA - orderB
+      }
+      return a.name.localeCompare(b.name, 'ja')
+    })
+
+    return categories
+  },
+
+  async createCategory(input: CreateCategoryInput): Promise<string> {
+    const docRef = await addDoc(collection(db, COLLECTION), {
+      name: input.name.trim(),
+    })
+    return docRef.id
+  },
+
+  async updateCategory(categoryId: string, input: CreateCategoryInput): Promise<void> {
+    const categoryRef = doc(db, COLLECTION, categoryId)
+    await updateDoc(categoryRef, {
+      name: input.name.trim(),
+    })
+  },
+
+  async deleteCategory(categoryId: string): Promise<void> {
+    const categoryRef = doc(db, COLLECTION, categoryId)
+    await deleteDoc(categoryRef)
+  },
+
+  async updateCategoryOrder(categoryId: string, order: number): Promise<void> {
+    const categoryRef = doc(db, COLLECTION, categoryId)
+    await updateDoc(categoryRef, { order })
+  },
+
+  async updateCategoriesOrder(updates: { id: string; order: number }[]): Promise<void> {
+    await Promise.all(
+      updates.map(({ id, order }) => updateDoc(doc(db, COLLECTION, id), { order }))
+    )
+  },
+}

--- a/src/services/incomeService.ts
+++ b/src/services/incomeService.ts
@@ -1,0 +1,174 @@
+import {
+  collection,
+  query,
+  where,
+  orderBy,
+  getDocs,
+  getDoc,
+  doc,
+  writeBatch,
+  Timestamp,
+  increment,
+  setDoc,
+  type DocumentData,
+} from 'firebase/firestore'
+import { db } from '../firebase/config'
+import { monthlyTotalPeriodId } from './expenseService'
+import type { Income, CreateIncomeInput, UpdateIncomeInput } from '../types'
+
+const COLLECTION = 'incomes'
+
+function monthlyIncomeTotalDocRef(userId: string, year: number, month: number) {
+  return doc(db, 'users', userId, 'monthlyIncomeTotals', monthlyTotalPeriodId(year, month))
+}
+
+function docToIncome(id: string, d: DocumentData): Income {
+  return { id, ...d } as Income
+}
+
+function sameCalendarMonth(a: Date, b: Date): boolean {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth()
+}
+
+function applyMonthlyIncomeDeltaInBatch(
+  batch: ReturnType<typeof writeBatch>,
+  userId: string,
+  incomeDate: Date,
+  delta: number
+): void {
+  const y = incomeDate.getFullYear()
+  const m = incomeDate.getMonth() + 1
+  const ref = monthlyIncomeTotalDocRef(userId, y, m)
+  batch.set(
+    ref,
+    {
+      userId,
+      year: y,
+      month: m,
+      total: increment(delta),
+      updatedAt: Timestamp.now(),
+    },
+    { merge: true }
+  )
+}
+
+function monthDateRangeTimestamps(year: number, month: number): { start: Timestamp; end: Timestamp } {
+  const start = new Date(year, month - 1, 1)
+  const end = new Date(year, month, 0, 23, 59, 59, 999)
+  return { start: Timestamp.fromDate(start), end: Timestamp.fromDate(end) }
+}
+
+function incomesInMonthOrderedQuery(userId: string, year: number, month: number) {
+  const { start, end } = monthDateRangeTimestamps(year, month)
+  return query(
+    collection(db, COLLECTION),
+    where('userId', '==', userId),
+    where('date', '>=', start),
+    where('date', '<=', end),
+    orderBy('date', 'desc')
+  )
+}
+
+export const incomeService = {
+  async getIncomesInMonth(userId: string, year: number, month: number): Promise<Income[]> {
+    const snap = await getDocs(incomesInMonthOrderedQuery(userId, year, month))
+    const list: Income[] = []
+    snap.forEach((d) => {
+      list.push(docToIncome(d.id, d.data()))
+    })
+    return list
+  },
+
+  async getMonthlyIncomeTotalForDisplay(userId: string, year: number, month: number): Promise<number> {
+    const ref = monthlyIncomeTotalDocRef(userId, year, month)
+    const snap = await getDoc(ref)
+    if (snap.exists()) {
+      return Number(snap.data()?.total ?? 0)
+    }
+    const list = await this.getIncomesInMonth(userId, year, month)
+    const total = list.reduce((s, i) => s + (i.amount || 0), 0)
+    await setDoc(ref, {
+      userId,
+      year,
+      month,
+      total,
+      updatedAt: Timestamp.now(),
+    })
+    return total
+  },
+
+  async createIncome(userId: string, input: CreateIncomeInput): Promise<string> {
+    const now = Timestamp.now()
+    const incomeDate = Timestamp.fromDate(input.date)
+
+    const batch = writeBatch(db)
+    const incomeRef = doc(collection(db, COLLECTION))
+    batch.set(incomeRef, {
+      userId,
+      date: incomeDate,
+      amount: input.amount,
+      category: input.category,
+      description: input.description || '',
+      createdAt: now,
+      updatedAt: now,
+    })
+    applyMonthlyIncomeDeltaInBatch(batch, userId, input.date, input.amount)
+    await batch.commit()
+    return incomeRef.id
+  },
+
+  async updateIncome(incomeId: string, input: UpdateIncomeInput): Promise<void> {
+    const incomeRef = doc(db, COLLECTION, incomeId)
+    const oldSnap = await getDoc(incomeRef)
+    if (!oldSnap.exists()) {
+      throw new Error('Income not found')
+    }
+    const old = oldSnap.data()
+    const oldUserId = old.userId as string
+    const oldDate = (old.date as Timestamp).toDate()
+    const oldAmount = (old.amount as number) || 0
+
+    const newDate = input.date ?? oldDate
+    const newAmount = input.amount !== undefined ? input.amount : oldAmount
+
+    const updateData: Record<string, unknown> = {
+      updatedAt: Timestamp.now(),
+    }
+    if (input.date) updateData.date = Timestamp.fromDate(input.date)
+    if (input.amount !== undefined) updateData.amount = input.amount
+    if (input.category) updateData.category = input.category
+    if (input.description !== undefined) updateData.description = input.description
+
+    const batch = writeBatch(db)
+    batch.update(incomeRef, updateData as Record<string, never>)
+
+    if (sameCalendarMonth(oldDate, newDate)) {
+      const delta = newAmount - oldAmount
+      if (delta !== 0) {
+        applyMonthlyIncomeDeltaInBatch(batch, oldUserId, oldDate, delta)
+      }
+    } else {
+      applyMonthlyIncomeDeltaInBatch(batch, oldUserId, oldDate, -oldAmount)
+      applyMonthlyIncomeDeltaInBatch(batch, oldUserId, newDate, newAmount)
+    }
+
+    await batch.commit()
+  },
+
+  async deleteIncome(incomeId: string): Promise<void> {
+    const incomeRef = doc(db, COLLECTION, incomeId)
+    const oldSnap = await getDoc(incomeRef)
+    if (!oldSnap.exists()) {
+      throw new Error('Income not found')
+    }
+    const old = oldSnap.data()
+    const userId = old.userId as string
+    const incomeDate = (old.date as Timestamp).toDate()
+    const amount = (old.amount as number) || 0
+
+    const batch = writeBatch(db)
+    batch.delete(incomeRef)
+    applyMonthlyIncomeDeltaInBatch(batch, userId, incomeDate, -amount)
+    await batch.commit()
+  },
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -60,3 +60,53 @@ export interface CreateTagInput {
   categoryId: string
 }
 
+/** 月次予算（全体・カテゴリー別・タグ別）。ドキュメント ID は periodId または periodId__cat__ / periodId__tag__ 接尾辞 */
+export interface MonthlyBudget {
+  id: string
+  userId: string
+  year: number
+  month: number
+  amountLimit: number
+  categoryId: string | null
+  categoryName: string | null
+  tagId: string | null
+  tagName: string | null
+  createdAt?: Timestamp
+  updatedAt: Timestamp
+}
+
+/** setBudget 用。全体はすべて省略。カテゴリー別・タグ別は同時に指定しない */
+export interface SetBudgetOptions {
+  categoryId?: string
+  categoryName?: string
+  tagId?: string
+  tagName?: string
+}
+
+// Income型の定義
+export interface Income {
+  id: string
+  date: Timestamp
+  amount: number
+  userId: string
+  /** 収入カテゴリー名（給与など） */
+  category: string
+  description: string
+  createdAt: Timestamp
+  updatedAt: Timestamp
+}
+
+export interface CreateIncomeInput {
+  date: Date
+  amount: number
+  category: string
+  description?: string
+}
+
+export interface UpdateIncomeInput {
+  date?: Date
+  amount?: number
+  category?: string
+  description?: string
+}
+

--- a/src/utils/budgetCarryover.test.ts
+++ b/src/utils/budgetCarryover.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildYearMonthBudgetSpent,
+  computeCarryoverChain,
+  formatCarryoverYen,
+} from './budgetCarryover'
+
+describe('computeCarryoverChain', () => {
+  it('carries unused budget to the next month', () => {
+    const result = computeCarryoverChain([
+      { year: 2026, month: 1, budgetLimit: 100_000, spent: 70_000 },
+      { year: 2026, month: 2, budgetLimit: 100_000, spent: 110_000 },
+      { year: 2026, month: 3, budgetLimit: 100_000, spent: 50_000 },
+    ])
+
+    expect(result[0]).toMatchObject({
+      carryIn: 0,
+      available: 100_000,
+      remaining: 30_000,
+      carryOut: 30_000,
+    })
+    expect(result[1]).toMatchObject({
+      carryIn: 30_000,
+      available: 130_000,
+      remaining: 20_000,
+      carryOut: 20_000,
+    })
+    expect(result[2]).toMatchObject({
+      carryIn: 20_000,
+      available: 120_000,
+      remaining: 70_000,
+      carryOut: 70_000,
+    })
+  })
+
+  it('carries deficit as negative to the next month', () => {
+    const result = computeCarryoverChain([
+      { year: 2026, month: 1, budgetLimit: 50_000, spent: 80_000 },
+      { year: 2026, month: 2, budgetLimit: 50_000, spent: 10_000 },
+    ])
+
+    expect(result[0]).toMatchObject({
+      remaining: -30_000,
+      carryOut: -30_000,
+    })
+    expect(result[1]).toMatchObject({
+      carryIn: -30_000,
+      available: 20_000,
+      remaining: 10_000,
+      carryOut: 10_000,
+    })
+  })
+
+  it('treats unset budget with spending as negative carry', () => {
+    const result = computeCarryoverChain([
+      { year: 2026, month: 1, budgetLimit: 100_000, spent: 40_000 },
+      { year: 2026, month: 2, budgetLimit: null, spent: 10_000 },
+      { year: 2026, month: 3, budgetLimit: 100_000, spent: 0 },
+    ])
+
+    expect(result[0].carryOut).toBe(60_000)
+    expect(result[1]).toMatchObject({
+      carryIn: 60_000,
+      available: 60_000,
+      remaining: 50_000,
+      carryOut: 50_000,
+    })
+    expect(result[2].carryIn).toBe(50_000)
+  })
+
+  it('makes unset budget month negative when spend exceeds carry-in', () => {
+    const result = computeCarryoverChain([
+      { year: 2026, month: 1, budgetLimit: null, spent: 25_000 },
+      { year: 2026, month: 2, budgetLimit: 100_000, spent: 0 },
+    ])
+
+    expect(result[0]).toMatchObject({
+      carryIn: 0,
+      available: 0,
+      remaining: -25_000,
+      carryOut: -25_000,
+    })
+    expect(result[1]).toMatchObject({
+      carryIn: -25_000,
+      available: 75_000,
+    })
+  })
+
+  it('uses initialCarryIn for the first month (including negative)', () => {
+    const result = computeCarryoverChain(
+      [{ year: 2026, month: 1, budgetLimit: 100_000, spent: 90_000 }],
+      -25_000
+    )
+    expect(result[0]).toMatchObject({
+      carryIn: -25_000,
+      available: 75_000,
+      remaining: -15_000,
+      carryOut: -15_000,
+    })
+  })
+})
+
+describe('buildYearMonthBudgetSpent', () => {
+  it('builds 12 months', () => {
+    const list = buildYearMonthBudgetSpent(
+      2026,
+      { 1: 100, 3: 200 },
+      { 1: 50, 2: 10 }
+    )
+    expect(list).toHaveLength(12)
+    expect(list[0]).toEqual({ year: 2026, month: 1, budgetLimit: 100, spent: 50 })
+    expect(list[1]).toEqual({ year: 2026, month: 2, budgetLimit: null, spent: 10 })
+    expect(list[2]).toEqual({ year: 2026, month: 3, budgetLimit: 200, spent: 0 })
+  })
+})
+
+describe('formatCarryoverYen', () => {
+  it('formats positive and negative', () => {
+    expect(formatCarryoverYen(1200)).toBe('¥1,200')
+    expect(formatCarryoverYen(-1200)).toBe('−¥1,200')
+  })
+})

--- a/src/utils/budgetCarryover.ts
+++ b/src/utils/budgetCarryover.ts
@@ -1,0 +1,83 @@
+/**
+ * 月次全体予算の繰越計算。
+ *
+ * 方針:
+ * - 予算設定あり: 繰越(次月へ) = 予算 + 繰入 − 実績（マイナス可）
+ * - 予算未設定: 繰越(次月へ) = 繰入 − 実績（実績があればマイナスになり得る）
+ * - 超過・未設定月の支出は翌月の有効予算を減らす（マイナス繰越）
+ */
+
+export type MonthBudgetSpent = {
+  year: number
+  month: number
+  /** null = 予算未設定 */
+  budgetLimit: number | null
+  spent: number
+}
+
+export type MonthCarryover = {
+  year: number
+  month: number
+  budgetLimit: number | null
+  spent: number
+  /** 前月から繰り入れた額（マイナス可） */
+  carryIn: number
+  /** 有効予算。予算あり: 予算+繰入 / 未設定: 繰入のみ */
+  available: number
+  /** available − spent（マイナス可） */
+  remaining: number
+  /** 翌月へ繰り越す額（remaining と同値、マイナス可） */
+  carryOut: number
+}
+
+export function computeCarryoverChain(
+  months: MonthBudgetSpent[],
+  initialCarryIn = 0
+): MonthCarryover[] {
+  let carryIn = Number.isFinite(initialCarryIn) ? initialCarryIn : 0
+  const out: MonthCarryover[] = []
+
+  for (const m of months) {
+    const spent = Number.isFinite(m.spent) ? m.spent : 0
+    const available = (m.budgetLimit ?? 0) + carryIn
+    const remaining = available - spent
+    const carryOut = remaining
+    out.push({
+      year: m.year,
+      month: m.month,
+      budgetLimit: m.budgetLimit,
+      spent,
+      carryIn,
+      available,
+      remaining,
+      carryOut,
+    })
+    carryIn = carryOut
+  }
+
+  return out
+}
+
+/** 1〜12月分の入力から、表示年のチェーン用 MonthBudgetSpent を組み立てる */
+export function buildYearMonthBudgetSpent(
+  year: number,
+  budgetByMonth: Record<number, number | null>,
+  spentByMonth: Record<number, number>
+): MonthBudgetSpent[] {
+  const list: MonthBudgetSpent[] = []
+  for (let month = 1; month <= 12; month++) {
+    list.push({
+      year,
+      month,
+      budgetLimit: budgetByMonth[month] ?? null,
+      spent: spentByMonth[month] ?? 0,
+    })
+  }
+  return list
+}
+
+/** 繰越・繰入などの金額表示（マイナスは先頭に −） */
+export function formatCarryoverYen(n: number): string {
+  const abs = Math.round(Math.abs(n)).toLocaleString()
+  return n < 0 ? `−¥${abs}` : `¥${abs}`
+}

--- a/src/utils/budgetMonth.test.ts
+++ b/src/utils/budgetMonth.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest'
+import { previousCalendarMonth } from './budgetMonth'
+
+describe('previousCalendarMonth', () => {
+  it('returns previous month in same year', () => {
+    expect(previousCalendarMonth(2026, 4)).toEqual({ year: 2026, month: 3 })
+  })
+
+  it('returns December of previous year when month is January', () => {
+    expect(previousCalendarMonth(2026, 1)).toEqual({ year: 2025, month: 12 })
+  })
+})

--- a/src/utils/budgetMonth.ts
+++ b/src/utils/budgetMonth.ts
@@ -1,0 +1,7 @@
+/** 暦月の直前の月（1月なら前年12月） */
+export function previousCalendarMonth(year: number, month: number): { year: number; month: number } {
+  if (month <= 1) {
+    return { year: year - 1, month: 12 }
+  }
+  return { year, month: month - 1 }
+}

--- a/src/utils/budgetSpentBreakdown.test.ts
+++ b/src/utils/budgetSpentBreakdown.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+import { Timestamp } from 'firebase/firestore'
+import {
+  buildScopedBudgetProgress,
+  parseExpenseTagNames,
+  sumSpentForCategory,
+  sumSpentForTag,
+} from './budgetSpentBreakdown'
+import type { Expense, MonthlyBudget } from '../types'
+
+function expense(partial: Partial<Expense> & Pick<Expense, 'amount' | 'bigCategory' | 'tags'>): Expense {
+  const ts = Timestamp.now()
+  return {
+    id: partial.id ?? 'e1',
+    date: ts,
+    userId: 'u1',
+    createdAt: ts,
+    updatedAt: ts,
+    paymentMethod: '',
+    description: '',
+    ...partial,
+  }
+}
+
+function budget(partial: Partial<MonthlyBudget>): MonthlyBudget {
+  return {
+    id: 'b1',
+    userId: 'u1',
+    year: 2026,
+    month: 4,
+    amountLimit: 10000,
+    categoryId: null,
+    categoryName: null,
+    tagId: null,
+    tagName: null,
+    updatedAt: Timestamp.now(),
+    ...partial,
+  }
+}
+
+describe('parseExpenseTagNames', () => {
+  it('splits comma-separated tags', () => {
+    expect(parseExpenseTagNames('ランチ, コンビニ')).toEqual(['ランチ', 'コンビニ'])
+    expect(parseExpenseTagNames('ランチ,コンビニ')).toEqual(['ランチ', 'コンビニ'])
+  })
+})
+
+describe('sumSpentForCategory', () => {
+  it('sums matching bigCategory', () => {
+    const list = [
+      expense({ amount: 1000, bigCategory: '食費', tags: '' }),
+      expense({ amount: 2000, bigCategory: '交通', tags: '' }),
+      expense({ amount: 500, bigCategory: '食費', tags: '' }),
+    ]
+    expect(sumSpentForCategory(list, '食費')).toBe(1500)
+  })
+})
+
+describe('sumSpentForTag', () => {
+  it('counts full amount when tag is included', () => {
+    const list = [
+      expense({ amount: 1000, bigCategory: '食費', tags: 'ランチ, 同僚' }),
+      expense({ amount: 2000, bigCategory: '食費', tags: 'コンビニ' }),
+    ]
+    expect(sumSpentForTag(list, 'ランチ')).toBe(1000)
+    expect(sumSpentForTag(list, '同僚')).toBe(1000)
+  })
+})
+
+describe('buildScopedBudgetProgress', () => {
+  it('builds category and tag rows', () => {
+    const budgets = [
+      budget({
+        id: 'c1',
+        categoryId: 'cat1',
+        categoryName: '食費',
+        amountLimit: 5000,
+      }),
+      budget({
+        id: 't1',
+        tagId: 'tag1',
+        tagName: 'ランチ',
+        amountLimit: 2000,
+      }),
+      budget({ id: 'total', amountLimit: 50000 }),
+    ]
+    const expenses = [
+      expense({ amount: 3000, bigCategory: '食費', tags: 'ランチ' }),
+      expense({ amount: 500, bigCategory: '食費', tags: '' }),
+    ]
+    const rows = buildScopedBudgetProgress(budgets, expenses)
+    expect(rows).toHaveLength(2)
+    expect(rows[0]).toMatchObject({
+      kind: 'category',
+      label: '食費',
+      used: 3500,
+      remaining: 1500,
+      over: false,
+    })
+    expect(rows[1]).toMatchObject({
+      kind: 'tag',
+      label: 'ランチ',
+      used: 3000,
+      remaining: -1000,
+      over: true,
+    })
+  })
+})

--- a/src/utils/budgetSpentBreakdown.ts
+++ b/src/utils/budgetSpentBreakdown.ts
@@ -1,0 +1,92 @@
+import type { Expense, MonthlyBudget } from '../types'
+
+/** Expense.tags（カンマ区切り）をタグ名配列に分解。MonthlySummary と同じ区切り */
+export function parseExpenseTagNames(tags: string): string[] {
+  return tags
+    .split(',')
+    .map((t) => t.trim())
+    .filter(Boolean)
+}
+
+/**
+ * カテゴリー別予算の実績。
+ * Expense.bigCategory と budget.categoryName を文字列一致で突合。
+ */
+export function sumSpentForCategory(expenses: Expense[], categoryName: string): number {
+  let sum = 0
+  for (const e of expenses) {
+    if ((e.bigCategory || '') === categoryName) {
+      sum += e.amount || 0
+    }
+  }
+  return sum
+}
+
+/**
+ * タグ別予算の実績。
+ * そのタグを含む支出は金額を全額カウント（複数タグでも按分しない＝上限監視を厳しめに）。
+ */
+export function sumSpentForTag(expenses: Expense[], tagName: string): number {
+  let sum = 0
+  for (const e of expenses) {
+    const names = parseExpenseTagNames(e.tags || '')
+    if (names.includes(tagName)) {
+      sum += e.amount || 0
+    }
+  }
+  return sum
+}
+
+export type ScopedBudgetProgress = {
+  key: string
+  kind: 'category' | 'tag'
+  label: string
+  limit: number
+  used: number
+  remaining: number
+  over: boolean
+  ratio: number
+}
+
+export function buildScopedBudgetProgress(
+  budgets: MonthlyBudget[],
+  expenses: Expense[]
+): ScopedBudgetProgress[] {
+  const rows: ScopedBudgetProgress[] = []
+
+  for (const b of budgets) {
+    if (b.categoryId && b.categoryName && !b.tagId) {
+      const used = sumSpentForCategory(expenses, b.categoryName)
+      const remaining = b.amountLimit - used
+      rows.push({
+        key: `cat:${b.categoryId}`,
+        kind: 'category',
+        label: b.categoryName,
+        limit: b.amountLimit,
+        used,
+        remaining,
+        over: used > b.amountLimit,
+        ratio: b.amountLimit > 0 ? used / b.amountLimit : used > 0 ? Infinity : 0,
+      })
+    } else if (b.tagId && b.tagName) {
+      const used = sumSpentForTag(expenses, b.tagName)
+      const remaining = b.amountLimit - used
+      rows.push({
+        key: `tag:${b.tagId}`,
+        kind: 'tag',
+        label: b.tagName,
+        limit: b.amountLimit,
+        used,
+        remaining,
+        over: used > b.amountLimit,
+        ratio: b.amountLimit > 0 ? used / b.amountLimit : used > 0 ? Infinity : 0,
+      })
+    }
+  }
+
+  rows.sort((a, b) => {
+    if (a.kind !== b.kind) return a.kind === 'category' ? -1 : 1
+    return a.label.localeCompare(b.label, 'ja')
+  })
+  return rows
+}

--- a/src/utils/firestoreReadCache.test.ts
+++ b/src/utils/firestoreReadCache.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  cacheGet,
+  cacheSet,
+  cacheInvalidatePrefix,
+  spentYearCacheKey,
+  totalBudgetYearCacheKey,
+} from './firestoreReadCache'
+
+describe('firestoreReadCache', () => {
+  beforeEach(() => {
+    cacheInvalidatePrefix('')
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    cacheInvalidatePrefix('')
+  })
+
+  it('returns undefined for missing keys', () => {
+    expect(cacheGet('missing')).toBeUndefined()
+  })
+
+  it('stores and retrieves values', () => {
+    cacheSet('k', { a: 1 })
+    expect(cacheGet<{ a: number }>('k')).toEqual({ a: 1 })
+  })
+
+  it('expires values after ttl', () => {
+    vi.useFakeTimers()
+    cacheSet('ttl', 42, 1000)
+    expect(cacheGet<number>('ttl')).toBe(42)
+    vi.advanceTimersByTime(1001)
+    expect(cacheGet<number>('ttl')).toBeUndefined()
+  })
+
+  it('invalidates by prefix', () => {
+    cacheSet('spent:u1:2026:1-12', { 1: 100 })
+    cacheSet('totalBudget:u1:2026', { 1: 50 })
+    cacheInvalidatePrefix('spent:u1:')
+    expect(cacheGet('spent:u1:2026:1-12')).toBeUndefined()
+    expect(cacheGet('totalBudget:u1:2026')).toEqual({ 1: 50 })
+  })
+
+  it('builds stable cache keys', () => {
+    expect(spentYearCacheKey('u1', 2026, 8)).toBe('spent:u1:2026:1-8')
+    expect(totalBudgetYearCacheKey('u1', 2026)).toBe('totalBudget:u1:2026')
+  })
+})

--- a/src/utils/firestoreReadCache.ts
+++ b/src/utils/firestoreReadCache.ts
@@ -1,0 +1,38 @@
+/**
+ * セッション内の Firestore 読取結果キャッシュ（TTL）。
+ * ダッシュボード／予算ページ間で year 単位の繰越入力を再利用する。
+ */
+
+type Entry<T> = { value: T; expiresAt: number }
+
+const DEFAULT_TTL_MS = 5 * 60 * 1000
+
+const store = new Map<string, Entry<unknown>>()
+
+export function cacheGet<T>(key: string): T | undefined {
+  const e = store.get(key)
+  if (!e) return undefined
+  if (Date.now() > e.expiresAt) {
+    store.delete(key)
+    return undefined
+  }
+  return e.value as T
+}
+
+export function cacheSet<T>(key: string, value: T, ttlMs = DEFAULT_TTL_MS): void {
+  store.set(key, { value, expiresAt: Date.now() + ttlMs })
+}
+
+export function cacheInvalidatePrefix(prefix: string): void {
+  for (const key of store.keys()) {
+    if (key.startsWith(prefix)) store.delete(key)
+  }
+}
+
+export function spentYearCacheKey(userId: string, year: number, throughMonth: number): string {
+  return `spent:${userId}:${year}:1-${throughMonth}`
+}
+
+export function totalBudgetYearCacheKey(userId: string, year: number): string {
+  return `totalBudget:${userId}:${year}`
+}

--- a/src/utils/formUtils.ts
+++ b/src/utils/formUtils.ts
@@ -9,3 +9,10 @@ export const getInitialExpenseFormData = () => ({
   description: '',
 })
 
+export const getInitialIncomeFormData = () => ({
+  date: new Date().toISOString().split('T')[0],
+  amount: '',
+  category: '',
+  description: '',
+})
+


### PR DESCRIPTION
月次予算（全体／カテゴリ／タグ）と収入登録を導入し、集計ドキュメントとページング・遅延読込で各画面の読取回数を抑える。

# 概要
- 月予算機能と読取回数を抑える実装

# 変更内容
- 月予算機能実装
- 収入登録機能実装
- 読取制御

# レビューチェックリスト
- [ ] コードが実行可能である
- [ ] 単体テスト / E2E テストを追加 or 既存テストをパス
- [ ] lint エラーがない
- [ ] 依存関係に不要な変更がない
- [ ] ドキュメントを更新した（必要な場合）