### PR TITLE
feat: 収入を予算・繰越の有効予算計算に反映

### DIFF
--- a/src/components/BudgetProgressBar.test.tsx
+++ b/src/components/BudgetProgressBar.test.tsx
@@ -24,6 +24,21 @@ describe('BudgetProgressBar', () => {
     expect(screen.getByText(/60/)).toBeInTheDocument()
   })
 
+  it('includes income in available budget', () => {
+    render(
+      <BudgetProgressBar
+        used={40_000}
+        limit={100_000}
+        income={20_000}
+        budgetSettingsTo="/budget"
+      />
+    )
+    // 40/120 ≈ 33%
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '33')
+    expect(screen.getByText(/収入/)).toBeInTheDocument()
+    expect(screen.getByText(/残り/)).toBeInTheDocument()
+  })
+
   it('includes carry-in in available budget', () => {
     render(
       <BudgetProgressBar

--- a/src/components/BudgetProgressBar.tsx
+++ b/src/components/BudgetProgressBar.tsx
@@ -8,6 +8,8 @@ export type BudgetProgressBarProps = {
   limit: number | null
   /** 前月からの繰入（円） */
   carryIn?: number
+  /** 当月の収入合計（円）。有効予算に加算 */
+  income?: number
   loading?: boolean
   /** 予算設定ページへのパス（クエリ付き可） */
   budgetSettingsTo: string
@@ -18,12 +20,13 @@ function formatYen(n: number): string {
 }
 
 /**
- * ダッシュボード用：全体予算（＋繰入）に対する消化率と残り／超過を表示する。
+ * ダッシュボード用：全体予算（＋繰入＋収入）に対する消化率と残り／超過を表示する。
  */
 export function BudgetProgressBar({
   used,
   limit,
   carryIn = 0,
+  income = 0,
   loading,
   budgetSettingsTo,
 }: BudgetProgressBarProps) {
@@ -53,7 +56,8 @@ export function BudgetProgressBar({
   }
 
   const safeCarryIn = carryIn
-  const available = limit + safeCarryIn
+  const safeIncome = Number.isFinite(income) ? income : 0
+  const available = limit + safeCarryIn + safeIncome
   const ratio = available > 0 ? used / available : used > 0 ? Number.POSITIVE_INFINITY : 0
   const over = used > available
   const barPct =
@@ -66,9 +70,16 @@ export function BudgetProgressBar({
       : safeCarryIn > 0
         ? ` + 繰越 ${formatYen(safeCarryIn)}`
         : ` − 繰越不足 ${formatYen(Math.abs(safeCarryIn))}`
+  const incomeLabel = safeIncome > 0 ? ` + 収入 ${formatYen(safeIncome)}` : ''
   const statusText = over
-    ? `${formatYen(used - available)} 超過。有効予算 ${formatYen(available)}（予算 ${formatYen(limit)}${carryLabel}）、使用額 ${formatYen(used)}。`
-    : `残り ${formatYen(remaining)}。有効予算 ${formatYen(available)}（予算 ${formatYen(limit)}${carryLabel}）、使用額 ${formatYen(used)}。`
+    ? `${formatYen(used - available)} 超過。有効予算 ${formatYen(available)}（予算 ${formatYen(limit)}${carryLabel}${incomeLabel}）、使用額 ${formatYen(used)}。`
+    : `残り ${formatYen(remaining)}。有効予算 ${formatYen(available)}（予算 ${formatYen(limit)}${carryLabel}${incomeLabel}）、使用額 ${formatYen(used)}。`
+
+  const rateExtraParts: string[] = []
+  if (safeCarryIn > 0) rateExtraParts.push(`繰越 ${formatYen(safeCarryIn)}`)
+  else if (safeCarryIn < 0) rateExtraParts.push(`繰越 ${formatYen(safeCarryIn)}`)
+  if (safeIncome > 0) rateExtraParts.push(`収入 ${formatYen(safeIncome)}`)
+  const rateExtra = rateExtraParts.length > 0 ? ` · ${rateExtraParts.join(' · ')}` : ''
 
   return (
     <div className="budget-progress budget-progress--active">
@@ -98,11 +109,7 @@ export function BudgetProgressBar({
         </span>
         <span className="budget-progress-rate" aria-hidden="true">
           {Number.isFinite(ratio) ? `${Math.round(ratio * 100)}% 使用` : '—'}
-          {safeCarryIn > 0
-            ? ` · 繰越 ${formatYen(safeCarryIn)}`
-            : safeCarryIn < 0
-              ? ` · 繰越 ${formatYen(safeCarryIn)}`
-              : ''}
+          {rateExtra}
         </span>
         <Link to={budgetSettingsTo} className="budget-progress-settings-link budget-progress-settings-link--inline">
           予算を編集

--- a/src/hooks/useMonthBudgetCarryover.test.tsx
+++ b/src/hooks/useMonthBudgetCarryover.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { useMonthBudgetCarryover } from './useMonthBudgetCarryover'
 import { listTotalBudgetLimitsForYear } from '../services/budgetService'
 import { expenseService } from '../services/expenseService'
+import { incomeService } from '../services/incomeService'
 
 vi.mock('../services/budgetService', () => ({
   listTotalBudgetLimitsForYear: vi.fn(),
@@ -14,13 +15,19 @@ vi.mock('../services/expenseService', () => ({
   },
 }))
 
+vi.mock('../services/incomeService', () => ({
+  incomeService: {
+    getIncomeByMonthForYear: vi.fn(),
+  },
+}))
+
 function emptyBudgetMap(): Record<number, number | null> {
   const m: Record<number, number | null> = {}
   for (let i = 1; i <= 12; i++) m[i] = null
   return m
 }
 
-function emptySpentMap(): Record<number, number> {
+function emptyAmountMap(): Record<number, number> {
   const m: Record<number, number> = {}
   for (let i = 1; i <= 12; i++) m[i] = 0
   return m
@@ -29,6 +36,7 @@ function emptySpentMap(): Record<number, number> {
 describe('useMonthBudgetCarryover', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(incomeService.getIncomeByMonthForYear).mockResolvedValue(emptyAmountMap())
   })
 
   it('does nothing when userId is undefined', async () => {
@@ -42,20 +50,22 @@ describe('useMonthBudgetCarryover', () => {
     expect(result.current.carryover).toBeNull()
   })
 
-  it('computes carryIn from previous year December carryOut', async () => {
+  it('computes carryIn including income in available budget', async () => {
     const prevBudgets = emptyBudgetMap()
     prevBudgets[12] = 100_000
-    const prevSpent = emptySpentMap()
+    const prevSpent = emptyAmountMap()
     prevSpent[12] = 40_000
+    const prevIncome = emptyAmountMap()
+    prevIncome[12] = 10_000
 
     const curBudgets = emptyBudgetMap()
     curBudgets[1] = 100_000
     curBudgets[2] = 100_000
     curBudgets[3] = 100_000
-    const curSpent = emptySpentMap()
-    curSpent[1] = 0
-    curSpent[2] = 0
+    const curSpent = emptyAmountMap()
     curSpent[3] = 10_000
+    const curIncome = emptyAmountMap()
+    curIncome[3] = 5_000
 
     vi.mocked(listTotalBudgetLimitsForYear)
       .mockResolvedValueOnce(prevBudgets)
@@ -63,6 +73,9 @@ describe('useMonthBudgetCarryover', () => {
     vi.mocked(expenseService.getSpentByMonthForYear)
       .mockResolvedValueOnce(prevSpent)
       .mockResolvedValueOnce(curSpent)
+    vi.mocked(incomeService.getIncomeByMonthForYear)
+      .mockResolvedValueOnce(prevIncome)
+      .mockResolvedValueOnce(curIncome)
 
     const { result } = renderHook(() => useMonthBudgetCarryover('user-1', 2026, 3))
 
@@ -70,18 +83,19 @@ describe('useMonthBudgetCarryover', () => {
       expect(result.current.loading).toBe(false)
     })
 
-    expect(listTotalBudgetLimitsForYear).toHaveBeenCalledWith('user-1', 2025)
-    expect(listTotalBudgetLimitsForYear).toHaveBeenCalledWith('user-1', 2026)
-    expect(expenseService.getSpentByMonthForYear).toHaveBeenCalledWith('user-1', 2025, 12)
-    expect(expenseService.getSpentByMonthForYear).toHaveBeenCalledWith('user-1', 2026, 3)
+    expect(incomeService.getIncomeByMonthForYear).toHaveBeenCalledWith('user-1', 2025, 12)
+    expect(incomeService.getIncomeByMonthForYear).toHaveBeenCalledWith('user-1', 2026, 3)
 
-    // prev Dec remaining 60_000 → Jan carryIn; Jan/Feb unused accumulate
+    // prev Dec: 100k + 10k income - 40k = 70k carryOut
+    // Jan: 100k+70k = 170k; Feb: 100k+170k = 270k carry to Mar
     expect(result.current.carryover).toMatchObject({
       year: 2026,
       month: 3,
       budgetLimit: 100_000,
       spent: 10_000,
-      carryIn: 260_000,
+      income: 5_000,
+      carryIn: 270_000,
+      available: 375_000,
     })
     expect(result.current.error).toBeNull()
   })

--- a/src/hooks/useMonthBudgetCarryover.ts
+++ b/src/hooks/useMonthBudgetCarryover.ts
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { listTotalBudgetLimitsForYear } from '../services/budgetService'
 import { expenseService } from '../services/expenseService'
+import { incomeService } from '../services/incomeService'
 import {
   buildYearMonthBudgetSpent,
   computeCarryoverChain,
@@ -9,9 +10,7 @@ import {
 
 /**
  * 指定月の全体予算について、前月までの繰越を加味した有効予算を算出する。
- * - 全体予算のみ取得（カテゴリー／タグ別は読まない）
- * - 当年の実績は選択月まで
- * - 前年は年初からのチェーンに必要な12か月
+ * 収入は有効予算に加算する（予算 + 繰入 + 収入 − 実績）。
  */
 export function useMonthBudgetCarryover(
   userId: string | undefined,
@@ -21,10 +20,16 @@ export function useMonthBudgetCarryover(
   carryover: MonthCarryover | null
   loading: boolean
   error: Error | null
+  refresh: () => void
 } {
   const [carryover, setCarryover] = useState<MonthCarryover | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<Error | null>(null)
+  const [refreshTick, setRefreshTick] = useState(0)
+
+  const refresh = useCallback(() => {
+    setRefreshTick((t) => t + 1)
+  }, [])
 
   useEffect(() => {
     if (!userId) {
@@ -39,21 +44,24 @@ export function useMonthBudgetCarryover(
       setLoading(true)
       setError(null)
       try {
-        const [prevBudgetMap, curBudgetMap, prevSpent, curSpent] = await Promise.all([
-          listTotalBudgetLimitsForYear(userId, year - 1),
-          listTotalBudgetLimitsForYear(userId, year),
-          expenseService.getSpentByMonthForYear(userId, year - 1, 12),
-          expenseService.getSpentByMonthForYear(userId, year, month),
-        ])
+        const [prevBudgetMap, curBudgetMap, prevSpent, curSpent, prevIncome, curIncome] =
+          await Promise.all([
+            listTotalBudgetLimitsForYear(userId, year - 1),
+            listTotalBudgetLimitsForYear(userId, year),
+            expenseService.getSpentByMonthForYear(userId, year - 1, 12),
+            expenseService.getSpentByMonthForYear(userId, year, month),
+            incomeService.getIncomeByMonthForYear(userId, year - 1, 12),
+            incomeService.getIncomeByMonthForYear(userId, year, month),
+          ])
         if (cancelled) return
 
         const prevChain = computeCarryoverChain(
-          buildYearMonthBudgetSpent(year - 1, prevBudgetMap, prevSpent),
+          buildYearMonthBudgetSpent(year - 1, prevBudgetMap, prevSpent, prevIncome),
           0
         )
         const initialCarryIn = prevChain[11]?.carryOut ?? 0
         const curChain = computeCarryoverChain(
-          buildYearMonthBudgetSpent(year, curBudgetMap, curSpent),
+          buildYearMonthBudgetSpent(year, curBudgetMap, curSpent, curIncome),
           initialCarryIn
         )
         const row = curChain.find((r) => r.month === month) ?? null
@@ -71,7 +79,7 @@ export function useMonthBudgetCarryover(
     return () => {
       cancelled = true
     }
-  }, [userId, year, month])
+  }, [userId, year, month, refreshTick])
 
-  return { carryover, loading, error }
+  return { carryover, loading, error, refresh }
 }

--- a/src/pages/Budget/Budget.css
+++ b/src/pages/Budget/Budget.css
@@ -12,7 +12,7 @@
   flex-wrap: wrap;
   gap: 1rem;
   margin-bottom: 1.5rem;
-  max-width: 56rem;
+  max-width: 64rem;
   margin-left: auto;
   margin-right: auto;
 }
@@ -40,7 +40,7 @@
 }
 
 .budget-main {
-  max-width: 56rem;
+  max-width: 64rem;
   margin: 0 auto;
   display: flex;
   flex-direction: column;

--- a/src/pages/Budget/Budget.tsx
+++ b/src/pages/Budget/Budget.tsx
@@ -12,6 +12,7 @@ import {
   deleteBudget,
 } from '../../services/budgetService'
 import { expenseService } from '../../services/expenseService'
+import { incomeService } from '../../services/incomeService'
 import { previousCalendarMonth } from '../../utils/budgetMonth'
 import {
   buildYearMonthBudgetSpent,
@@ -72,6 +73,7 @@ const Budget = () => {
   const [saveOk, setSaveOk] = useState(false)
   const [bulkAmount, setBulkAmount] = useState('')
   const [spentByMonth, setSpentByMonth] = useState<Record<number, number>>({})
+  const [incomeByMonth, setIncomeByMonth] = useState<Record<number, number>>({})
   const [initialCarryIn, setInitialCarryIn] = useState(0)
 
   const loadYearTotals = useCallback(async () => {
@@ -80,11 +82,13 @@ const Budget = () => {
     setLoadError(null)
     setSaveOk(false)
     try {
-      const [totalLimits, spent, prevBudgetMap, prevSpent] = await Promise.all([
+      const [totalLimits, spent, income, prevBudgetMap, prevSpent, prevIncome] = await Promise.all([
         listTotalBudgetLimitsForYear(user.uid, year),
         expenseService.getSpentByMonthForYear(user.uid, year, 12),
+        incomeService.getIncomeByMonthForYear(user.uid, year, 12),
         listTotalBudgetLimitsForYear(user.uid, year - 1),
         expenseService.getSpentByMonthForYear(user.uid, year - 1, 12),
+        incomeService.getIncomeByMonthForYear(user.uid, year - 1, 12),
       ])
       const savedMonths = new Set<number>()
       for (let m = 1; m <= 12; m++) {
@@ -92,9 +96,10 @@ const Budget = () => {
       }
       setSavedTotalMonths(savedMonths)
       setSpentByMonth(spent)
+      setIncomeByMonth(income)
 
       const prevChain = computeCarryoverChain(
-        buildYearMonthBudgetSpent(year - 1, prevBudgetMap, prevSpent),
+        buildYearMonthBudgetSpent(year - 1, prevBudgetMap, prevSpent, prevIncome),
         0
       )
       setInitialCarryIn(prevChain[11]?.carryOut ?? 0)
@@ -247,7 +252,7 @@ const Budget = () => {
       budgetByMonth[m] = typeof parsed === 'number' ? parsed : null
     }
     const chain = computeCarryoverChain(
-      buildYearMonthBudgetSpent(year, budgetByMonth, spentByMonth),
+      buildYearMonthBudgetSpent(year, budgetByMonth, spentByMonth, incomeByMonth),
       initialCarryIn
     )
     const map: Record<number, MonthCarryover> = {}
@@ -255,7 +260,7 @@ const Budget = () => {
       map[row.month] = row
     }
     return map
-  }, [year, monthTotals, spentByMonth, initialCarryIn])
+  }, [year, monthTotals, spentByMonth, incomeByMonth, initialCarryIn])
 
   const applyBulkToEmpty = () => {
     const n = parseOptionalAmount(bulkAmount)
@@ -537,6 +542,7 @@ const Budget = () => {
                     <tr>
                       <th scope="col">月</th>
                       <th scope="col">全体予算</th>
+                      <th scope="col">収入</th>
                       <th scope="col">実績</th>
                       <th scope="col">繰入</th>
                       <th scope="col">有効予算</th>
@@ -568,6 +574,9 @@ const Budget = () => {
                               aria-label={`${m}月の全体予算`}
                               placeholder="未設定"
                             />
+                          </td>
+                          <td className="budget-num">
+                            ¥{(co?.income ?? incomeByMonth[m] ?? 0).toLocaleString()}
                           </td>
                           <td className="budget-num">
                             ¥{(co?.spent ?? spentByMonth[m] ?? 0).toLocaleString()}

--- a/src/pages/Dashboard/Dashboard.test.tsx
+++ b/src/pages/Dashboard/Dashboard.test.tsx
@@ -33,6 +33,7 @@ vi.mock('../../hooks/useMonthBudgetCarryover', () => ({
     carryover: null,
     loading: false,
     error: null,
+    refresh: vi.fn(),
   })),
 }))
 
@@ -143,6 +144,7 @@ describe('Dashboard', () => {
       carryover: null,
       loading: false,
       error: null,
+      refresh: vi.fn(),
     })
     vi.mocked(useMonthScopedBudgets).mockReturnValue({
       categoryBudgets: [],

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -68,7 +68,7 @@ const Dashboard = () => {
     selectedYearMonth.year,
     selectedYearMonth.month
   )
-  const { carryover, loading: carryoverLoading } = useMonthBudgetCarryover(
+  const { carryover, loading: carryoverLoading, refresh: refreshCarryover } = useMonthBudgetCarryover(
     user?.uid,
     selectedYearMonth.year,
     selectedYearMonth.month
@@ -118,11 +118,13 @@ const Dashboard = () => {
   const handleExpenseSuccess = async () => {
     setShowExpenseForm(false)
     await refreshAfterMutation()
+    refreshCarryover()
   }
 
   const handleIncomeSuccess = async () => {
     setShowIncomeForm(false)
     await refreshIncomesAfterMutation()
+    refreshCarryover()
   }
 
   const listBusy = loadingExpenses
@@ -188,6 +190,7 @@ const Dashboard = () => {
                   used={monthlyTotal}
                   limit={totalBudget?.amountLimit ?? null}
                   carryIn={carryover?.carryIn ?? 0}
+                  income={monthlyIncomeTotal}
                   loading={budgetLoading || carryoverLoading}
                   budgetSettingsTo={`/budget?year=${selectedYearMonth.year}&month=${selectedYearMonth.month}`}
                 />
@@ -369,8 +372,14 @@ const Dashboard = () => {
           expense={selectedExpense}
           userId={user.uid}
           onClose={() => setSelectedExpense(null)}
-          onUpdate={() => void refreshAfterMutation()}
-          onDelete={() => void refreshAfterMutation()}
+          onUpdate={() => {
+            void refreshAfterMutation()
+            refreshCarryover()
+          }}
+          onDelete={() => {
+            void refreshAfterMutation()
+            refreshCarryover()
+          }}
         />
       )}
 
@@ -379,8 +388,14 @@ const Dashboard = () => {
           income={selectedIncome}
           userId={user.uid}
           onClose={() => setSelectedIncome(null)}
-          onUpdate={() => void refreshIncomesAfterMutation()}
-          onDelete={() => void refreshIncomesAfterMutation()}
+          onUpdate={() => {
+            void refreshIncomesAfterMutation()
+            refreshCarryover()
+          }}
+          onDelete={() => {
+            void refreshIncomesAfterMutation()
+            refreshCarryover()
+          }}
         />
       )}
     </div>

--- a/src/services/incomeService.ts
+++ b/src/services/incomeService.ts
@@ -14,6 +14,12 @@ import {
 } from 'firebase/firestore'
 import { db } from '../firebase/config'
 import { monthlyTotalPeriodId } from './expenseService'
+import {
+  cacheGet,
+  cacheInvalidatePrefix,
+  cacheSet,
+  incomeYearCacheKey,
+} from '../utils/firestoreReadCache'
 import type { Income, CreateIncomeInput, UpdateIncomeInput } from '../types'
 
 const COLLECTION = 'incomes'
@@ -97,6 +103,39 @@ export const incomeService = {
     return total
   },
 
+  /**
+   * 指定年の1〜throughMonth の収入合計（円）。セッションキャッシュあり。
+   */
+  async getIncomeByMonthForYear(
+    userId: string,
+    year: number,
+    throughMonth = 12
+  ): Promise<Record<number, number>> {
+    const end = Math.min(12, Math.max(1, throughMonth))
+    const cacheKey = incomeYearCacheKey(userId, year, end)
+    const cached = cacheGet<Record<number, number>>(cacheKey)
+    if (cached) return { ...cached }
+
+    const pairs = await Promise.all(
+      Array.from({ length: end }, async (_, i) => {
+        const month = i + 1
+        const total = await this.getMonthlyIncomeTotalForDisplay(userId, year, month)
+        return [month, total] as const
+      })
+    )
+    const map: Record<number, number> = {}
+    for (let m = 1; m <= 12; m++) map[m] = 0
+    for (const [month, total] of pairs) {
+      map[month] = total
+    }
+    cacheSet(cacheKey, map)
+    return map
+  },
+
+  invalidateIncomeCaches(userId: string): void {
+    cacheInvalidatePrefix(`income:${userId}:`)
+  },
+
   async createIncome(userId: string, input: CreateIncomeInput): Promise<string> {
     const now = Timestamp.now()
     const incomeDate = Timestamp.fromDate(input.date)
@@ -114,6 +153,7 @@ export const incomeService = {
     })
     applyMonthlyIncomeDeltaInBatch(batch, userId, input.date, input.amount)
     await batch.commit()
+    this.invalidateIncomeCaches(userId)
     return incomeRef.id
   },
 
@@ -153,6 +193,7 @@ export const incomeService = {
     }
 
     await batch.commit()
+    this.invalidateIncomeCaches(oldUserId)
   },
 
   async deleteIncome(incomeId: string): Promise<void> {
@@ -170,5 +211,6 @@ export const incomeService = {
     batch.delete(incomeRef)
     applyMonthlyIncomeDeltaInBatch(batch, userId, incomeDate, -amount)
     await batch.commit()
+    this.invalidateIncomeCaches(userId)
   },
 }

--- a/src/utils/budgetCarryover.test.ts
+++ b/src/utils/budgetCarryover.test.ts
@@ -108,9 +108,41 @@ describe('buildYearMonthBudgetSpent', () => {
       { 1: 50, 2: 10 }
     )
     expect(list).toHaveLength(12)
-    expect(list[0]).toEqual({ year: 2026, month: 1, budgetLimit: 100, spent: 50 })
-    expect(list[1]).toEqual({ year: 2026, month: 2, budgetLimit: null, spent: 10 })
-    expect(list[2]).toEqual({ year: 2026, month: 3, budgetLimit: 200, spent: 0 })
+    expect(list[0]).toEqual({ year: 2026, month: 1, budgetLimit: 100, spent: 50, income: 0 })
+    expect(list[1]).toEqual({ year: 2026, month: 2, budgetLimit: null, spent: 10, income: 0 })
+    expect(list[2]).toEqual({ year: 2026, month: 3, budgetLimit: 200, spent: 0, income: 0 })
+  })
+
+  it('includes income by month when provided', () => {
+    const list = buildYearMonthBudgetSpent(2026, { 1: 100 }, { 1: 50 }, { 1: 20 })
+    expect(list[0]).toEqual({
+      year: 2026,
+      month: 1,
+      budgetLimit: 100,
+      spent: 50,
+      income: 20,
+    })
+  })
+})
+
+describe('computeCarryoverChain with income', () => {
+  it('adds income into available and carry-out', () => {
+    const result = computeCarryoverChain([
+      { year: 2026, month: 1, budgetLimit: 100_000, spent: 80_000, income: 30_000 },
+      { year: 2026, month: 2, budgetLimit: 100_000, spent: 50_000, income: 0 },
+    ])
+    // available = 100k + 0 + 30k = 130k; remaining = 50k
+    expect(result[0]).toMatchObject({
+      income: 30_000,
+      available: 130_000,
+      remaining: 50_000,
+      carryOut: 50_000,
+    })
+    expect(result[1]).toMatchObject({
+      carryIn: 50_000,
+      available: 150_000,
+      remaining: 100_000,
+    })
   })
 })
 

--- a/src/utils/budgetCarryover.ts
+++ b/src/utils/budgetCarryover.ts
@@ -2,8 +2,8 @@
  * 月次全体予算の繰越計算。
  *
  * 方針:
- * - 予算設定あり: 繰越(次月へ) = 予算 + 繰入 − 実績（マイナス可）
- * - 予算未設定: 繰越(次月へ) = 繰入 − 実績（実績があればマイナスになり得る）
+ * - 有効予算 = 予算（未設定は0）+ 繰入 + 収入
+ * - 繰越(次月へ) = 有効予算 − 実績（マイナス可）
  * - 超過・未設定月の支出は翌月の有効予算を減らす（マイナス繰越）
  */
 
@@ -13,6 +13,8 @@ export type MonthBudgetSpent = {
   /** null = 予算未設定 */
   budgetLimit: number | null
   spent: number
+  /** その月の収入合計（円） */
+  income?: number
 }
 
 export type MonthCarryover = {
@@ -20,9 +22,10 @@ export type MonthCarryover = {
   month: number
   budgetLimit: number | null
   spent: number
+  income: number
   /** 前月から繰り入れた額（マイナス可） */
   carryIn: number
-  /** 有効予算。予算あり: 予算+繰入 / 未設定: 繰入のみ */
+  /** 有効予算 = 予算(0可) + 繰入 + 収入 */
   available: number
   /** available − spent（マイナス可） */
   remaining: number
@@ -39,7 +42,8 @@ export function computeCarryoverChain(
 
   for (const m of months) {
     const spent = Number.isFinite(m.spent) ? m.spent : 0
-    const available = (m.budgetLimit ?? 0) + carryIn
+    const income = Number.isFinite(m.income) ? (m.income as number) : 0
+    const available = (m.budgetLimit ?? 0) + carryIn + income
     const remaining = available - spent
     const carryOut = remaining
     out.push({
@@ -47,6 +51,7 @@ export function computeCarryoverChain(
       month: m.month,
       budgetLimit: m.budgetLimit,
       spent,
+      income,
       carryIn,
       available,
       remaining,
@@ -62,7 +67,8 @@ export function computeCarryoverChain(
 export function buildYearMonthBudgetSpent(
   year: number,
   budgetByMonth: Record<number, number | null>,
-  spentByMonth: Record<number, number>
+  spentByMonth: Record<number, number>,
+  incomeByMonth: Record<number, number> = {}
 ): MonthBudgetSpent[] {
   const list: MonthBudgetSpent[] = []
   for (let month = 1; month <= 12; month++) {
@@ -71,6 +77,7 @@ export function buildYearMonthBudgetSpent(
       month,
       budgetLimit: budgetByMonth[month] ?? null,
       spent: spentByMonth[month] ?? 0,
+      income: incomeByMonth[month] ?? 0,
     })
   }
   return list

--- a/src/utils/firestoreReadCache.ts
+++ b/src/utils/firestoreReadCache.ts
@@ -33,6 +33,10 @@ export function spentYearCacheKey(userId: string, year: number, throughMonth: nu
   return `spent:${userId}:${year}:1-${throughMonth}`
 }
 
+export function incomeYearCacheKey(userId: string, year: number, throughMonth: number): string {
+  return `income:${userId}:${year}:1-${throughMonth}`
+}
+
 export function totalBudgetYearCacheKey(userId: string, year: number): string {
   return `totalBudget:${userId}:${year}`
 }


### PR DESCRIPTION
有効予算を「予算 + 繰入 + 収入」とし、ダッシュボードの進捗と予算ページの繰越に組み込む。

# 概要
- 何を実装したか（1行）

# 変更内容
- 主な変更点を箇条書きで

# レビューチェックリスト
- [ ] コードが実行可能である
- [ ] 単体テスト / E2E テストを追加 or 既存テストをパス
- [ ] lint エラーがない
- [ ] 依存関係に不要な変更がない
- [ ] ドキュメントを更新した（必要な場合）