### PR TITLE
feat: プロフィールからメールアドレス変更を可能にする

### DIFF
--- a/src/components/ProtectedRoute.test.tsx
+++ b/src/components/ProtectedRoute.test.tsx
@@ -40,6 +40,7 @@ describe('ProtectedRoute', () => {
       user: mockUser,
       loading: false,
       signOutUser: vi.fn(),
+      refreshUser: vi.fn(),
     })
 
     render(
@@ -56,6 +57,7 @@ describe('ProtectedRoute', () => {
       user: null,
       loading: true,
       signOutUser: vi.fn(),
+      refreshUser: vi.fn(),
     })
 
     render(
@@ -73,6 +75,7 @@ describe('ProtectedRoute', () => {
       user: null,
       loading: false,
       signOutUser: vi.fn(),
+      refreshUser: vi.fn(),
     })
 
     render(

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,5 +1,5 @@
 // React からコンテキスト/フック周りの機能と型をインポート
-import { ReactNode, createContext, useContext, useEffect, useState } from 'react'
+import { ReactNode, createContext, useCallback, useContext, useEffect, useState } from 'react'
 // Firebase Authentication で利用するメソッドと型をインポート
 import { onAuthStateChanged, signOut, User } from 'firebase/auth'
 // 初期化済み Firebase アプリから取り出した認証インスタンス
@@ -10,6 +10,8 @@ interface AuthContextValue {
   user: User | null
   loading: boolean
   signOutUser: () => Promise<void>
+  /** Firebase Auth から最新のユーザー情報を再取得する（メール変更反映など） */
+  refreshUser: () => Promise<void>
 }
 
 // 認証関連の値を共有するためのコンテキストを作成
@@ -24,6 +26,8 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
   const [user, setUser] = useState<User | null>(null)
   // 認証状態の確認中かどうか
   const [loading, setLoading] = useState(true)
+  // user オブジェクト参照が変わらなくても再描画するためのカウンタ
+  const [, setUserEpoch] = useState(0)
 
   useEffect(() => {
     // Firebase Auth の認証状態を監視し、ユーザー情報を保持する
@@ -41,10 +45,24 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     await signOut(auth)
   }
 
+  const refreshUser = useCallback(async () => {
+    const currentUser = auth.currentUser
+    if (!currentUser) {
+      setUser(null)
+      return
+    }
+
+    await currentUser.reload()
+    setUser(auth.currentUser)
+    // reload() は同一参照を更新するため、epoch で購読側の再描画を促す
+    setUserEpoch((epoch) => epoch + 1)
+  }, [])
+
   const value: AuthContextValue = {
     user,
     loading,
     signOutUser,
+    refreshUser,
   }
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
@@ -60,5 +78,3 @@ export const useAuth = () => {
 
   return context
 }
-
-

--- a/src/pages/CategoryTagManagement/CategoryTagManagement.test.tsx
+++ b/src/pages/CategoryTagManagement/CategoryTagManagement.test.tsx
@@ -63,6 +63,7 @@ describe('CategoryTagManagement', () => {
       user: mockUser,
       loading: false,
       signOutUser: vi.fn(),
+      refreshUser: vi.fn(),
     })
     vi.mocked(useUserName).mockReturnValue({
       displayName: 'Test User',
@@ -98,6 +99,7 @@ describe('CategoryTagManagement', () => {
       user: mockUser,
       loading: false,
       signOutUser: vi.fn(),
+      refreshUser: vi.fn(),
     })
     vi.mocked(useUserName).mockReturnValue({
       displayName: 'Test User',
@@ -134,6 +136,7 @@ describe('CategoryTagManagement', () => {
       user: mockUser,
       loading: false,
       signOutUser: vi.fn(),
+      refreshUser: vi.fn(),
     })
     vi.mocked(useUserName).mockReturnValue({
       displayName: 'Test User',

--- a/src/pages/Dashboard/Dashboard.test.tsx
+++ b/src/pages/Dashboard/Dashboard.test.tsx
@@ -172,6 +172,7 @@ describe('Dashboard', () => {
       user: mockUser,
       loading: false,
       signOutUser: vi.fn(),
+      refreshUser: vi.fn(),
     })
     vi.mocked(useUserName).mockReturnValue({
       displayName: 'Test User',
@@ -191,6 +192,7 @@ describe('Dashboard', () => {
       user: mockUser,
       loading: false,
       signOutUser: vi.fn(),
+      refreshUser: vi.fn(),
     })
     vi.mocked(useUserName).mockReturnValue({
       displayName: null,
@@ -214,6 +216,7 @@ describe('Dashboard', () => {
       user: mockUser,
       loading: false,
       signOutUser: vi.fn(),
+      refreshUser: vi.fn(),
     })
     vi.mocked(useUserName).mockReturnValue({
       displayName: 'Test User',
@@ -236,6 +239,7 @@ describe('Dashboard', () => {
       user: mockUser,
       loading: false,
       signOutUser: vi.fn(),
+      refreshUser: vi.fn(),
     })
     vi.mocked(useUserName).mockReturnValue({
       displayName: 'Test User',
@@ -258,6 +262,7 @@ describe('Dashboard', () => {
       user: mockUser,
       loading: false,
       signOutUser: vi.fn(),
+      refreshUser: vi.fn(),
     })
     vi.mocked(useUserName).mockReturnValue({
       displayName: 'Test User',
@@ -280,6 +285,7 @@ describe('Dashboard', () => {
       user: mockUser,
       loading: false,
       signOutUser: vi.fn(),
+      refreshUser: vi.fn(),
     })
     vi.mocked(useUserName).mockReturnValue({
       displayName: 'Test User',
@@ -306,6 +312,7 @@ describe('Dashboard', () => {
       user: mockUser,
       loading: false,
       signOutUser: vi.fn(),
+      refreshUser: vi.fn(),
     })
     vi.mocked(useUserName).mockReturnValue({
       displayName: 'Test User',
@@ -328,6 +335,7 @@ describe('Dashboard', () => {
       user: mockUser,
       loading: false,
       signOutUser: vi.fn(),
+      refreshUser: vi.fn(),
     })
     vi.mocked(useUserName).mockReturnValue({
       displayName: 'Test User',
@@ -349,6 +357,7 @@ describe('Dashboard', () => {
       user: mockUser,
       loading: false,
       signOutUser: vi.fn(),
+      refreshUser: vi.fn(),
     })
     vi.mocked(useUserName).mockReturnValue({
       displayName: 'Test User',
@@ -379,6 +388,7 @@ describe('Dashboard', () => {
       user: mockUser,
       loading: false,
       signOutUser: vi.fn(),
+      refreshUser: vi.fn(),
     })
     vi.mocked(useUserName).mockReturnValue({
       displayName: 'Test User',
@@ -417,6 +427,7 @@ describe('Dashboard', () => {
       user: mockUser,
       loading: false,
       signOutUser: vi.fn(),
+      refreshUser: vi.fn(),
     })
     vi.mocked(useUserName).mockReturnValue({
       displayName: 'Test User',

--- a/src/pages/Login/Login.test.tsx
+++ b/src/pages/Login/Login.test.tsx
@@ -23,6 +23,7 @@ describe('Login', () => {
       user: null,
       loading: false,
       signOutUser: vi.fn(),
+      refreshUser: vi.fn(),
     })
 
     render(<Login />)
@@ -37,6 +38,7 @@ describe('Login', () => {
       user: null,
       loading: true,
       signOutUser: vi.fn(),
+      refreshUser: vi.fn(),
     })
 
     render(<Login />)
@@ -51,6 +53,7 @@ describe('Login', () => {
       user: null,
       loading: false,
       signOutUser: vi.fn(),
+      refreshUser: vi.fn(),
     })
     vi.mocked(signInWithEmailAndPassword).mockResolvedValue({
       user: {} as never,
@@ -82,6 +85,7 @@ describe('Login', () => {
       user: null,
       loading: false,
       signOutUser: vi.fn(),
+      refreshUser: vi.fn(),
     })
     vi.mocked(signInWithEmailAndPassword).mockRejectedValue(new Error('Invalid credentials'))
 
@@ -107,6 +111,7 @@ describe('Login', () => {
       user: null,
       loading: false,
       signOutUser: vi.fn(),
+      refreshUser: vi.fn(),
     })
 
     render(<Login />)

--- a/src/pages/MonthlyExpenses/MonthlyExpenses.test.tsx
+++ b/src/pages/MonthlyExpenses/MonthlyExpenses.test.tsx
@@ -55,6 +55,7 @@ describe('MonthlyExpenses', () => {
       user: mockUser,
       loading: false,
       signOutUser: vi.fn(),
+      refreshUser: vi.fn(),
     })
     vi.mocked(useUserName).mockReturnValue({
       displayName: 'Test User',
@@ -94,6 +95,7 @@ describe('MonthlyExpenses', () => {
       user: mockUser,
       loading: false,
       signOutUser: vi.fn(),
+      refreshUser: vi.fn(),
     })
     vi.mocked(useUserName).mockReturnValue({
       displayName: null,
@@ -133,6 +135,7 @@ describe('MonthlyExpenses', () => {
       user: mockUser,
       loading: false,
       signOutUser: vi.fn(),
+      refreshUser: vi.fn(),
     })
     vi.mocked(useUserName).mockReturnValue({
       displayName: 'Test User',

--- a/src/pages/MonthlySummary/MonthlySummary.test.tsx
+++ b/src/pages/MonthlySummary/MonthlySummary.test.tsx
@@ -74,6 +74,7 @@ describe('MonthlySummary', () => {
       user: mockUser,
       loading: false,
       signOutUser: vi.fn(),
+      refreshUser: vi.fn(),
     })
     vi.mocked(useUserName).mockReturnValue({
       displayName: 'Test User',
@@ -100,6 +101,7 @@ describe('MonthlySummary', () => {
       user: mockUser,
       loading: false,
       signOutUser: vi.fn(),
+      refreshUser: vi.fn(),
     })
     vi.mocked(useUserName).mockReturnValue({
       displayName: null,
@@ -125,6 +127,7 @@ describe('MonthlySummary', () => {
       user: mockUser,
       loading: false,
       signOutUser: vi.fn(),
+      refreshUser: vi.fn(),
     })
     vi.mocked(useUserName).mockReturnValue({
       displayName: 'Test User',

--- a/src/pages/Profile/Profile.test.tsx
+++ b/src/pages/Profile/Profile.test.tsx
@@ -3,15 +3,24 @@ import { render, screen, waitFor } from '../../test/testUtils'
 import Profile from './Profile'
 import { useAuth } from '../../context/AuthContext'
 import { useUserName } from '../../hooks/useUserName'
-import { updateProfile } from 'firebase/auth'
+import {
+  EmailAuthProvider,
+  reauthenticateWithCredential,
+  updateProfile,
+  verifyBeforeUpdateEmail,
+} from 'firebase/auth'
 import { setDoc } from 'firebase/firestore'
 import type { User } from 'firebase/auth'
 
-// モック
 vi.mock('../../context/AuthContext')
 vi.mock('../../hooks/useUserName')
 vi.mock('firebase/auth', () => ({
   updateProfile: vi.fn(),
+  verifyBeforeUpdateEmail: vi.fn(),
+  reauthenticateWithCredential: vi.fn(),
+  EmailAuthProvider: {
+    credential: vi.fn(),
+  },
 }))
 vi.mock('firebase/firestore', () => ({
   doc: vi.fn(),
@@ -44,17 +53,21 @@ const mockUser = {
   toJSON: vi.fn(),
 } as unknown as User
 
+const mockAuthValue = (overrides: Partial<ReturnType<typeof useAuth>> = {}) => ({
+  user: mockUser,
+  loading: false,
+  signOutUser: vi.fn(),
+  refreshUser: vi.fn().mockResolvedValue(undefined),
+  ...overrides,
+})
+
 describe('Profile', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
   it('should render profile page with user information', () => {
-    vi.mocked(useAuth).mockReturnValue({
-      user: mockUser,
-      loading: false,
-      signOutUser: vi.fn(),
-    })
+    vi.mocked(useAuth).mockReturnValue(mockAuthValue())
     vi.mocked(useUserName).mockReturnValue({
       displayName: 'Test User',
       loading: false,
@@ -68,11 +81,7 @@ describe('Profile', () => {
   })
 
   it('should display loading state', () => {
-    vi.mocked(useAuth).mockReturnValue({
-      user: mockUser,
-      loading: false,
-      signOutUser: vi.fn(),
-    })
+    vi.mocked(useAuth).mockReturnValue(mockAuthValue())
     vi.mocked(useUserName).mockReturnValue({
       displayName: null,
       loading: true,
@@ -86,11 +95,7 @@ describe('Profile', () => {
   it('should switch to edit mode when edit button is clicked', async () => {
     const userEvent = (await import('@testing-library/user-event')).default.setup()
 
-    vi.mocked(useAuth).mockReturnValue({
-      user: mockUser,
-      loading: false,
-      signOutUser: vi.fn(),
-    })
+    vi.mocked(useAuth).mockReturnValue(mockAuthValue())
     vi.mocked(useUserName).mockReturnValue({
       displayName: 'Test User',
       loading: false,
@@ -103,18 +108,16 @@ describe('Profile', () => {
 
     await waitFor(() => {
       expect(screen.getByLabelText('名前')).toBeInTheDocument()
+      expect(screen.getByLabelText('メールアドレス')).toBeInTheDocument()
       expect(screen.getByDisplayValue('Test User')).toBeInTheDocument()
+      expect(screen.getByDisplayValue('test@example.com')).toBeInTheDocument()
     })
   })
 
   it('should update profile when form is submitted', async () => {
     const userEvent = (await import('@testing-library/user-event')).default.setup()
 
-    vi.mocked(useAuth).mockReturnValue({
-      user: mockUser,
-      loading: false,
-      signOutUser: vi.fn(),
-    })
+    vi.mocked(useAuth).mockReturnValue(mockAuthValue())
     vi.mocked(useUserName).mockReturnValue({
       displayName: 'Test User',
       loading: false,
@@ -139,16 +142,80 @@ describe('Profile', () => {
         displayName: 'Updated Name',
       })
     })
+    expect(verifyBeforeUpdateEmail).not.toHaveBeenCalled()
+  })
+
+  it('should request email change after reauthentication', async () => {
+    const userEvent = (await import('@testing-library/user-event')).default.setup()
+    const credential = { providerId: 'password' }
+
+    vi.mocked(useAuth).mockReturnValue(mockAuthValue())
+    vi.mocked(useUserName).mockReturnValue({
+      displayName: 'Test User',
+      loading: false,
+    })
+    vi.mocked(EmailAuthProvider.credential).mockReturnValue(credential as never)
+    vi.mocked(reauthenticateWithCredential).mockResolvedValue({} as never)
+    vi.mocked(verifyBeforeUpdateEmail).mockResolvedValue(undefined)
+
+    render(<Profile />)
+
+    await userEvent.click(screen.getByText('編集'))
+
+    const emailInput = screen.getByLabelText('メールアドレス')
+    await userEvent.clear(emailInput)
+    await userEvent.type(emailInput, 'new@example.com')
+
+    const passwordInput = await screen.findByLabelText('現在のパスワード')
+    await userEvent.type(passwordInput, 'secret-password')
+
+    await userEvent.click(screen.getByText('更新'))
+
+    await waitFor(() => {
+      expect(EmailAuthProvider.credential).toHaveBeenCalledWith(
+        'test@example.com',
+        'secret-password'
+      )
+      expect(reauthenticateWithCredential).toHaveBeenCalledWith(mockUser, credential)
+      expect(verifyBeforeUpdateEmail).toHaveBeenCalledWith(mockUser, 'new@example.com')
+    })
+
+    expect(
+      await screen.findByText(
+        '新しいメールアドレス宛に確認メールを送信しました。リンクを開くとメールアドレスが変更されます。'
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('should require password when changing email', async () => {
+    const userEvent = (await import('@testing-library/user-event')).default.setup()
+
+    vi.mocked(useAuth).mockReturnValue(mockAuthValue())
+    vi.mocked(useUserName).mockReturnValue({
+      displayName: 'Test User',
+      loading: false,
+    })
+
+    render(<Profile />)
+
+    await userEvent.click(screen.getByText('編集'))
+
+    const emailInput = screen.getByLabelText('メールアドレス')
+    await userEvent.clear(emailInput)
+    await userEvent.type(emailInput, 'new@example.com')
+
+    await userEvent.click(screen.getByText('更新'))
+
+    expect(
+      await screen.findByText('メールアドレスを変更するには現在のパスワードが必要です')
+    ).toBeInTheDocument()
+    expect(verifyBeforeUpdateEmail).not.toHaveBeenCalled()
   })
 
   it('should cancel editing when cancel button is clicked', async () => {
     const userEvent = (await import('@testing-library/user-event')).default.setup()
 
-    vi.mocked(useAuth).mockReturnValue({
-      user: mockUser,
-      loading: false,
-      signOutUser: vi.fn(),
-    })
+    vi.mocked(useAuth).mockReturnValue(mockAuthValue())
     vi.mocked(useUserName).mockReturnValue({
       displayName: 'Test User',
       loading: false,
@@ -169,19 +236,26 @@ describe('Profile', () => {
   })
 
   it('should not render when user is null', () => {
-    vi.mocked(useAuth).mockReturnValue({
-      user: null,
-      loading: false,
-      signOutUser: vi.fn(),
-    })
+    vi.mocked(useAuth).mockReturnValue(mockAuthValue({ user: null }))
     vi.mocked(useUserName).mockReturnValue({
       displayName: null,
       loading: false,
     })
 
     const { container } = render(<Profile />)
-    // userがnullの場合、コンポーネントはnullを返す
     expect(container.firstChild).toBeNull()
   })
-})
 
+  it('should refresh user on mount to sync latest email', () => {
+    const refreshUser = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(useAuth).mockReturnValue(mockAuthValue({ refreshUser }))
+    vi.mocked(useUserName).mockReturnValue({
+      displayName: 'Test User',
+      loading: false,
+    })
+
+    render(<Profile />)
+
+    expect(refreshUser).toHaveBeenCalled()
+  })
+})

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -1,22 +1,49 @@
 import { useState, useEffect } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
-import { updateProfile } from 'firebase/auth'
+import {
+  EmailAuthProvider,
+  reauthenticateWithCredential,
+  updateProfile,
+  verifyBeforeUpdateEmail,
+} from 'firebase/auth'
 import { doc, setDoc } from 'firebase/firestore'
 import { useAuth } from '../../context/AuthContext'
 import { useUserName } from '../../hooks/useUserName'
 import { db } from '../../firebase/config'
+import { mapAuthErrorMessage } from '../../utils/authErrors'
 import './Profile.css'
 
 const Profile = () => {
-  const { user, signOutUser } = useAuth()
+  const { user, signOutUser, refreshUser } = useAuth()
   const navigate = useNavigate()
   const { displayName, loading: loadingName } = useUserName(user)
 
   const [isEditing, setIsEditing] = useState<boolean>(false)
   const [name, setName] = useState<string>('')
+  const [email, setEmail] = useState<string>('')
+  const [currentPassword, setCurrentPassword] = useState<string>('')
   const [submitting, setSubmitting] = useState<boolean>(false)
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState<string | null>(null)
+
+  // 確認メール反映後など、Auth の最新情報を取り直す
+  useEffect(() => {
+    void refreshUser()
+
+    const syncLatestUser = () => {
+      if (document.visibilityState === 'visible') {
+        void refreshUser()
+      }
+    }
+
+    window.addEventListener('focus', syncLatestUser)
+    document.addEventListener('visibilitychange', syncLatestUser)
+
+    return () => {
+      window.removeEventListener('focus', syncLatestUser)
+      document.removeEventListener('visibilitychange', syncLatestUser)
+    }
+  }, [refreshUser])
 
   useEffect(() => {
     if (displayName) {
@@ -24,8 +51,20 @@ const Profile = () => {
     }
   }, [displayName])
 
+  useEffect(() => {
+    if (user?.email) {
+      setEmail(user.email)
+    }
+  }, [user?.email])
+
+  const isEmailChanged =
+    Boolean(user?.email) && email.trim().toLowerCase() !== user!.email!.toLowerCase()
+
   const handleEdit = () => {
     setIsEditing(true)
+    setName(displayName || '')
+    setEmail(user?.email || '')
+    setCurrentPassword('')
     setError(null)
     setSuccess(null)
   }
@@ -33,6 +72,8 @@ const Profile = () => {
   const handleCancel = () => {
     setIsEditing(false)
     setName(displayName || '')
+    setEmail(user?.email || '')
+    setCurrentPassword('')
     setError(null)
     setSuccess(null)
   }
@@ -42,8 +83,30 @@ const Profile = () => {
 
     if (!user) return
 
-    if (!name.trim()) {
+    const trimmedName = name.trim()
+    const trimmedEmail = email.trim()
+
+    if (!trimmedName) {
       setError('名前を入力してください')
+      return
+    }
+
+    if (!trimmedEmail) {
+      setError('メールアドレスを入力してください')
+      return
+    }
+
+    const nameChanged = trimmedName !== (displayName || '')
+    const emailChanged =
+      Boolean(user.email) && trimmedEmail.toLowerCase() !== user.email!.toLowerCase()
+
+    if (!nameChanged && !emailChanged) {
+      setError('変更がありません')
+      return
+    }
+
+    if (emailChanged && !currentPassword) {
+      setError('メールアドレスを変更するには現在のパスワードが必要です')
       return
     }
 
@@ -52,32 +115,51 @@ const Profile = () => {
     setSuccess(null)
 
     try {
-      // Firebase AuthのdisplayNameを更新
-      await updateProfile(user, {
-        displayName: name.trim(),
-      })
+      if (nameChanged) {
+        await updateProfile(user, {
+          displayName: trimmedName,
+        })
 
-      // Firestoreのusersコレクションも更新
-      const userRef = doc(db, 'users', user.uid)
-      await setDoc(
-        userRef,
-        {
-          name: name.trim(),
-          updatedAt: new Date(),
-        },
-        { merge: true }
-      )
+        const userRef = doc(db, 'users', user.uid)
+        await setDoc(
+          userRef,
+          {
+            name: trimmedName,
+            updatedAt: new Date(),
+          },
+          { merge: true }
+        )
+      }
 
-      setSuccess('プロフィールを更新しました')
-      setIsEditing(false)
-      
-      // ページをリロードして最新の情報を反映
-      setTimeout(() => {
-        window.location.reload()
-      }, 1000)
+      if (emailChanged) {
+        if (!user.email) {
+          throw new Error('現在のメールアドレスを取得できません')
+        }
+
+        const credential = EmailAuthProvider.credential(user.email, currentPassword)
+        await reauthenticateWithCredential(user, credential)
+        await verifyBeforeUpdateEmail(user, trimmedEmail)
+      }
+
+      if (emailChanged) {
+        setSuccess(
+          nameChanged
+            ? '名前を更新しました。新しいメールアドレス宛に確認メールを送信しました。リンクを開くとメールアドレスが変更されます。'
+            : '新しいメールアドレス宛に確認メールを送信しました。リンクを開くとメールアドレスが変更されます。'
+        )
+        setIsEditing(false)
+        setCurrentPassword('')
+        setEmail(user.email || '')
+      } else {
+        setSuccess('プロフィールを更新しました')
+        setIsEditing(false)
+        setTimeout(() => {
+          window.location.reload()
+        }, 1000)
+      }
     } catch (err) {
       console.error('Failed to update profile', err)
-      setError('プロフィールの更新に失敗しました')
+      setError(mapAuthErrorMessage(err, 'プロフィールの更新に失敗しました'))
     } finally {
       setSubmitting(false)
     }
@@ -145,15 +227,39 @@ const Profile = () => {
                   </div>
 
                   <div className="form-group">
-                    <label>メールアドレス</label>
+                    <label htmlFor="email">メールアドレス</label>
                     <input
                       type="email"
-                      value={user.email || ''}
-                      disabled
-                      className="disabled-input"
+                      id="email"
+                      value={email}
+                      onChange={(e) => setEmail(e.target.value)}
+                      placeholder="メールアドレスを入力"
+                      required
+                      disabled={submitting}
+                      autoComplete="email"
                     />
-                    <p className="form-hint">メールアドレスは変更できません</p>
+                    <p className="form-hint">
+                      変更する場合は確認メールのリンクを開くと反映されます
+                    </p>
                   </div>
+
+                  {isEmailChanged && (
+                    <div className="form-group">
+                      <label htmlFor="currentPassword">現在のパスワード</label>
+                      <input
+                        type="password"
+                        id="currentPassword"
+                        value={currentPassword}
+                        onChange={(e) => setCurrentPassword(e.target.value)}
+                        placeholder="現在のパスワードを入力"
+                        disabled={submitting}
+                        autoComplete="current-password"
+                      />
+                      <p className="form-hint">
+                        メールアドレス変更の確認のため入力してください
+                      </p>
+                    </div>
+                  )}
 
                   {error && <p className="error-message">{error}</p>}
                   {success && <p className="success-message">{success}</p>}
@@ -178,6 +284,7 @@ const Profile = () => {
                 </form>
               ) : (
                 <div className="profile-details">
+                  {success && <p className="success-message">{success}</p>}
                   <div className="profile-detail-row">
                     <span className="profile-detail-label">名前</span>
                     <span className="profile-detail-value">
@@ -227,4 +334,3 @@ const Profile = () => {
 }
 
 export default Profile
-

--- a/src/test/testUtils.tsx
+++ b/src/test/testUtils.tsx
@@ -9,6 +9,7 @@ vi.mock('../context/AuthContext', () => ({
     user: null,
     loading: false,
     signOutUser: vi.fn(),
+    refreshUser: vi.fn().mockResolvedValue(undefined),
   })),
   AuthProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
 }))

--- a/src/utils/authErrors.test.ts
+++ b/src/utils/authErrors.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { mapAuthErrorMessage } from './authErrors'
+
+describe('mapAuthErrorMessage', () => {
+  it('maps known auth error codes', () => {
+    expect(mapAuthErrorMessage({ code: 'auth/email-already-in-use' })).toBe(
+      'このメールアドレスは既に使用されています'
+    )
+    expect(mapAuthErrorMessage({ code: 'auth/wrong-password' })).toBe(
+      'パスワードが間違っています'
+    )
+  })
+
+  it('returns fallback for unknown errors', () => {
+    expect(mapAuthErrorMessage({ code: 'auth/unknown' }, 'カスタムエラー')).toBe(
+      'カスタムエラー'
+    )
+    expect(mapAuthErrorMessage(new Error('boom'))).toBe(
+      '操作に失敗しました。しばらくしてから再度お試しください'
+    )
+  })
+})

--- a/src/utils/authErrors.ts
+++ b/src/utils/authErrors.ts
@@ -1,0 +1,32 @@
+/** Firebase Auth のエラーを日本語メッセージに変換する */
+export const mapAuthErrorMessage = (
+  error: unknown,
+  fallback = '操作に失敗しました。しばらくしてから再度お試しください'
+): string => {
+  const code =
+    error && typeof error === 'object' && 'code' in error
+      ? String((error as { code?: string }).code)
+      : undefined
+
+  switch (code) {
+    case 'auth/invalid-email':
+      return 'メールアドレスの形式が正しくありません'
+    case 'auth/email-already-in-use':
+      return 'このメールアドレスは既に使用されています'
+    case 'auth/wrong-password':
+    case 'auth/invalid-credential':
+      return 'パスワードが間違っています'
+    case 'auth/requires-recent-login':
+      return 'セキュリティのため、再度ログインしてからお試しください'
+    case 'auth/too-many-requests':
+      return 'リクエストが多すぎます。しばらく待ってから再試行してください'
+    case 'auth/user-disabled':
+      return 'このユーザーは無効化されています'
+    case 'auth/user-mismatch':
+      return '認証情報が一致しません'
+    case 'auth/network-request-failed':
+      return 'ネットワークエラーが発生しました。接続を確認してください'
+    default:
+      return fallback
+  }
+}


### PR DESCRIPTION
再認証と確認メール経由で Firebase Auth のメールを更新し、画面復帰時に最新情報を再取得する。

# 概要
- メールアドレス変更機能

# 変更内容
- メールアドレスの変更

# レビューチェックリスト
- [ ] コードが実行可能である
- [ ] 単体テスト / E2E テストを追加 or 既存テストをパス
- [ ] lint エラーがない
- [ ] 依存関係に不要な変更がない
- [ ] ドキュメントを更新した（必要な場合）